### PR TITLE
Implement history and admin features

### DIFF
--- a/spielolympiade-backend/prisma/schema.prisma
+++ b/spielolympiade-backend/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Season {
   id       String  @id @default(uuid())
   year     Int
   name     String
+  finishedAt DateTime?
 
   teams       Team[]
   tournaments Tournament[]

--- a/spielolympiade-backend/prisma/seed.ts
+++ b/spielolympiade-backend/prisma/seed.ts
@@ -1,8 +1,10 @@
 
 import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
 const prisma = new PrismaClient();
 
 async function main() {
+  const pw = await bcrypt.hash('test', 10);
   const season = await prisma.season.create({
     data: {
       id: 'season-2024',
@@ -20,17 +22,17 @@ async function main() {
   });
 
   await prisma.$transaction([
-    prisma.user.create({ data: { id: '8ouu6z9z1', name: 'Luca', username: 'luca', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: 'idl0k1rw5', name: 'Seb', username: 'seb', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: '4z4bch1dt', name: 'BJ', username: 'bj', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: '7oxoq18uz', name: 'Jens', username: 'jens', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: 'xl3jdapud', name: 'Oskar', username: 'oskar', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: '9uvjuud71', name: 'Leo', username: 'leo', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: 'l8z0fjukn', name: 'Noah', username: 'noah', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: 'mxrty0x6m', name: 'Julian', username: 'julian', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: '93hmsiv8b', name: 'Louis', username: 'louis', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: 'vws3r4h7i', name: 'Andi', username: 'andi', passwordHash: 'test', role: 'player' } }),
-    prisma.user.create({ data: { id: 'dhcmob6mz', name: 'Pati', username: 'pati', passwordHash: 'test', role: 'player' } })
+    prisma.user.create({ data: { id: '8ouu6z9z1', name: 'Luca', username: 'luca', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: 'idl0k1rw5', name: 'Seb', username: 'seb', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: '4z4bch1dt', name: 'BJ', username: 'bj', passwordHash: pw, role: 'admin' } }),
+    prisma.user.create({ data: { id: '7oxoq18uz', name: 'Jens', username: 'jens', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: 'xl3jdapud', name: 'Oskar', username: 'oskar', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: '9uvjuud71', name: 'Leo', username: 'leo', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: 'l8z0fjukn', name: 'Noah', username: 'noah', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: 'mxrty0x6m', name: 'Julian', username: 'julian', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: '93hmsiv8b', name: 'Louis', username: 'louis', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: 'vws3r4h7i', name: 'Andi', username: 'andi', passwordHash: pw, role: 'player' } }),
+    prisma.user.create({ data: { id: 'dhcmob6mz', name: 'Pati', username: 'pati', passwordHash: pw, role: 'player' } })
   ]);
 
   await prisma.$transaction([

--- a/spielolympiade-backend/src/routes/auth.ts
+++ b/spielolympiade-backend/src/routes/auth.ts
@@ -1,19 +1,36 @@
 import express from "express";
 import jwt from "jsonwebtoken";
+import bcrypt from "bcrypt";
 import { Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
 
 const router = express.Router();
+const prisma = new PrismaClient();
 
-router.post("/login", (req: Request, res: Response) => {
-  const { username } = req.body;
+router.post("/login", async (req: Request, res: Response) => {
+  const { username, password } = req.body;
 
-  if (!username) {
-    res.status(400).json({ error: "Username fehlt" });
+  if (!username || !password) {
+    res.status(400).json({ error: "Username und Passwort erforderlich" });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({ where: { username } });
+
+  if (!user) {
+    res.status(401).json({ error: "Ungültige Anmeldedaten" });
+    return;
+  }
+
+  const match = await bcrypt.compare(password, user.passwordHash);
+
+  if (!match) {
+    res.status(401).json({ error: "Ungültige Anmeldedaten" });
     return;
   }
 
   const token = jwt.sign(
-    { username, role: "player" },
+    { id: user.id, username: user.username, role: user.role },
     process.env.JWT_SECRET || "secret",
     { expiresIn: "12h" }
   );

--- a/spielolympiade-backend/src/routes/matches.ts
+++ b/spielolympiade-backend/src/routes/matches.ts
@@ -112,4 +112,73 @@ router.post(
   }
 );
 
+// 📝 Ergebnis aktualisieren
+router.put(
+  "/:id/result",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const { team1Score, team2Score } = req.body;
+
+    const match = await prisma.match.findUnique({ where: { id } });
+
+    if (!match) {
+      res.status(404).json({ error: "Match nicht gefunden" });
+      return;
+    }
+
+    const winnerId =
+      team1Score > team2Score
+        ? match.team1Id
+        : team2Score > team1Score
+        ? match.team2Id
+        : null;
+
+    const updated = await prisma.match.update({
+      where: { id },
+      data: {
+        winnerId,
+        results: {
+          deleteMany: {},
+          create: [
+            { teamId: match.team1Id, score: team1Score },
+            { teamId: match.team2Id, score: team2Score },
+          ],
+        },
+      },
+      include: { results: true, winner: true },
+    });
+
+    res.json(updated);
+  }
+);
+
+// ❌ Ergebnis löschen
+router.delete(
+  "/:id/result",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+
+    const match = await prisma.match.findUnique({ where: { id } });
+
+    if (!match) {
+      res.status(404).json({ error: "Match nicht gefunden" });
+      return;
+    }
+
+    const cleared = await prisma.match.update({
+      where: { id },
+      data: {
+        playedAt: null,
+        winnerId: null,
+        results: { deleteMany: {} },
+      },
+      include: { results: true },
+    });
+
+    res.json(cleared);
+  }
+);
+
 export default router;

--- a/spielolympiade-backend/src/routes/seasons.ts
+++ b/spielolympiade-backend/src/routes/seasons.ts
@@ -50,6 +50,77 @@ router.get("/public/dashboard-data", async (_req, res) => {
   }
 });
 
+// 📜 GET /seasons/:id/history – Saison mit Matches & Ergebnissen
+router.get(
+  "/:id/history",
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+
+    const season = await prisma.season.findUnique({
+      where: { id },
+      include: {
+        teams: {
+          include: { members: { include: { user: true } } },
+        },
+        tournaments: {
+          include: {
+            matches: { include: { game: true, results: true, winner: true } },
+          },
+        },
+      },
+    });
+
+    if (!season) {
+      res.status(404).json({ error: "Saison nicht gefunden" });
+      return;
+    }
+
+    res.json(season);
+  }
+);
+
+// 🏆 GET /seasons/:id/table – Saison-Tabelle berechnen
+router.get("/:id/table", async (req: Request, res: Response): Promise<void> => {
+  const { id } = req.params;
+
+  const season = await prisma.season.findUnique({
+    where: { id },
+    include: { teams: true },
+  });
+
+  if (!season) {
+    res.status(404).json({ error: "Saison nicht gefunden" });
+    return;
+  }
+
+  const matches = await prisma.match.findMany({
+    where: { tournament: { seasonId: id }, winnerId: { not: null } },
+    select: { id: true, team1Id: true, team2Id: true, winnerId: true },
+  });
+
+  const table = season.teams.map((team) => {
+    const teamMatches = matches.filter(
+      (m) => m.team1Id === team.id || m.team2Id === team.id
+    );
+    const wins = teamMatches.filter((m) => m.winnerId === team.id).length;
+    const games = teamMatches.length;
+    const losses = games - wins;
+    const points = wins; // 1 Punkt pro Sieg
+    return {
+      id: team.id,
+      name: team.name,
+      spiele: games,
+      siege: wins,
+      niederlagen: losses,
+      points,
+    };
+  });
+
+  table.sort((a, b) => b.points - a.points);
+
+  res.json(table);
+});
+
 // ✅ POST /seasons – neue Saison anlegen (admin only)
 router.post(
   "/",
@@ -75,6 +146,55 @@ router.post(
     });
 
     res.status(201).json(season);
+  }
+);
+
+// 🌟 POST /seasons/start – vereinfachter Start einer Saison
+router.post(
+  "/start",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { year, name } = req.body;
+
+    if (!year || !name) {
+      res.status(400).json({ error: "year und name erforderlich" });
+      return;
+    }
+
+    const exists = await prisma.season.findFirst({ where: { year } });
+    if (exists) {
+      res.status(400).json({ error: "Saison existiert bereits" });
+      return;
+    }
+
+    const season = await prisma.season.create({ data: { year, name } });
+    await prisma.tournament.create({
+      data: { seasonId: season.id, system: "round_robin" },
+    });
+
+    res.status(201).json(season);
+  }
+);
+
+// ✅ Saison beenden (Passwortabfrage rudimentär)
+router.post(
+  "/:id/finish",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const { password } = req.body;
+
+    if (password !== "admin") {
+      res.status(401).json({ error: "Passwort falsch" });
+      return;
+    }
+
+    const season = await prisma.season.update({
+      where: { id },
+      data: { finishedAt: new Date() },
+    });
+
+    res.json(season);
   }
 );
 

--- a/spielolympiade-backend/src/routes/users.ts
+++ b/spielolympiade-backend/src/routes/users.ts
@@ -1,5 +1,7 @@
 import express, { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcrypt";
+import { authorizeRole } from "../middleware/auth";
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -55,6 +57,7 @@ router.get("/my-team", async (req: Request, res: Response): Promise<void> => {
     id: latestTeam.id,
     name: latestTeam.name,
     season: latestTeam.season.name,
+    seasonId: latestTeam.season.id,
     members: latestTeam.members.map((m) => m.user.name),
   });
 });
@@ -93,6 +96,73 @@ router.get(
     });
 
     res.json(matches);
+  }
+);
+
+// ----- Admin: Benutzer verwalten -----
+
+// Alle Nutzer auflisten
+router.get(
+  "/",
+  authorizeRole("admin"),
+  async (_req: Request, res: Response): Promise<void> => {
+    const users = await prisma.user.findMany({ orderBy: { username: "asc" } });
+    res.json(users);
+  }
+);
+
+// Neuen Nutzer anlegen
+router.post(
+  "/",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { name, username, password, role } = req.body;
+    if (!name || !username || !password) {
+      res.status(400).json({ error: "name, username, password erforderlich" });
+      return;
+    }
+    const hash = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: { name, username, passwordHash: hash, role: role || "player" },
+    });
+    res.status(201).json(user);
+  }
+);
+
+// Nutzer aktualisieren
+router.put(
+  "/:id",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const { name, username, password, role } = req.body;
+    const data: any = {};
+    if (name) data.name = name;
+    if (username) data.username = username;
+    if (role) data.role = role;
+    if (password) data.passwordHash = await bcrypt.hash(password, 10);
+
+    try {
+      const user = await prisma.user.update({ where: { id }, data });
+      res.json(user);
+    } catch {
+      res.status(404).json({ error: "User nicht gefunden" });
+    }
+  }
+);
+
+// Nutzer löschen
+router.delete(
+  "/:id",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    try {
+      await prisma.user.delete({ where: { id } });
+      res.sendStatus(204);
+    } catch {
+      res.status(404).json({ error: "User nicht gefunden" });
+    }
   }
 );
 

--- a/spielolympiade-frontend/src/app/app.component.html
+++ b/spielolympiade-frontend/src/app/app.component.html
@@ -1,1 +1,7 @@
+<nav class="main-nav" *ngIf="auth.isLoggedIn()">
+  <a routerLink="/dashboard">Dashboard</a>
+  <a routerLink="/history">Historie</a>
+  <a routerLink="/admin" *ngIf="auth.getUser()?.role === 'admin'">Admin</a>
+</nav>
+
 <router-outlet />

--- a/spielolympiade-frontend/src/app/app.component.scss
+++ b/spielolympiade-frontend/src/app/app.component.scss
@@ -1,0 +1,11 @@
+nav.main-nav {
+  display: flex;
+  gap: 1rem;
+  background: #eee;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  a {
+    text-decoration: none;
+    color: #333;
+  }
+}

--- a/spielolympiade-frontend/src/app/app.component.ts
+++ b/spielolympiade-frontend/src/app/app.component.ts
@@ -1,13 +1,15 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterLink } from '@angular/router';
+import { AuthService } from './core/auth.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, RouterLink],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
 export class AppComponent {
   title = 'spielolympiade-frontend';
+  constructor(public auth: AuthService) {}
 }

--- a/spielolympiade-frontend/src/app/core/auth.service.ts
+++ b/spielolympiade-frontend/src/app/core/auth.service.ts
@@ -16,9 +16,10 @@ export class AuthService {
 
   constructor(private http: HttpClient, private router: Router) {}
 
-  login(username: string) {
+  login(username: string, password: string) {
     return this.http.post<{ token: string }>(`${this.apiUrl}/login`, {
       username,
+      password,
     });
   }
 

--- a/spielolympiade-frontend/src/app/core/user.model.ts
+++ b/spielolympiade-frontend/src/app/core/user.model.ts
@@ -1,4 +1,5 @@
 export interface User {
+  id: string;
   username: string;
   role: 'admin' | 'player'; // ggf. später 'viewer' oder andere Rollen
   iat?: number; // optional: issued at

--- a/spielolympiade-frontend/src/app/pages/admin/admin.component.html
+++ b/spielolympiade-frontend/src/app/pages/admin/admin.component.html
@@ -1,1 +1,52 @@
-<p>admin works!</p>
+<div class="admin">
+  <h2>Neue Saison starten</h2>
+  <label>
+    Jahr:
+    <input type="number" [(ngModel)]="year" />
+  </label>
+  <label>
+    Name:
+    <input type="text" [(ngModel)]="name" />
+  </label>
+  <button (click)="startSeason()">Starten</button>
+
+  <h2>Spielergebnis eintragen</h2>
+  <label>
+    Match ID:
+    <input type="text" [(ngModel)]="matchId" />
+  </label>
+  <label>
+    Team1 Score:
+    <input type="number" [(ngModel)]="team1Score" />
+  </label>
+  <label>
+    Team2 Score:
+    <input type="number" [(ngModel)]="team2Score" />
+  </label>
+  <button (click)="saveResult()">Speichern</button>
+
+  <h2>Userverwaltung</h2>
+  <table class="users">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Username</th>
+        <th>Rolle</th>
+        <th>Aktion</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let u of users">
+        <td>{{ u.name }}</td>
+        <td>{{ u.username }}</td>
+        <td>
+          <select [ngModel]="u.role" (ngModelChange)="changeRole(u.id, $event)">
+            <option value="player">player</option>
+            <option value="admin">admin</option>
+          </select>
+        </td>
+        <td><button (click)="deleteUser(u.id)">Löschen</button></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/spielolympiade-frontend/src/app/pages/admin/admin.component.scss
+++ b/spielolympiade-frontend/src/app/pages/admin/admin.component.scss
@@ -1,0 +1,19 @@
+div.admin {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+
+  table.users {
+    width: 100%;
+    border-collapse: collapse;
+    th,
+    td {
+      border: 1px solid #ccc;
+      padding: 0.25rem;
+    }
+    th {
+      background: #f2f2f2;
+    }
+  }
+}

--- a/spielolympiade-frontend/src/app/pages/admin/admin.component.ts
+++ b/spielolympiade-frontend/src/app/pages/admin/admin.component.ts
@@ -1,12 +1,61 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+
+const API_URL = environment.apiUrl;
 
 @Component({
   selector: 'app-admin',
   standalone: true,
-  imports: [],
+  imports: [CommonModule, FormsModule],
   templateUrl: './admin.component.html',
-  styleUrl: './admin.component.scss'
+  styleUrls: ['./admin.component.scss']
 })
 export class AdminComponent {
+  http = inject(HttpClient);
 
+  year = new Date().getFullYear();
+  name = 'Spielolympiade ' + this.year;
+
+  users: any[] = [];
+
+  matchId = '';
+  team1Score = 0;
+  team2Score = 0;
+
+  ngOnInit(): void {
+    this.loadUsers();
+  }
+
+  loadUsers(): void {
+    this.http.get<any[]>(`${API_URL}/users`).subscribe((u) => (this.users = u));
+  }
+
+  startSeason(): void {
+    this.http
+      .post(`${API_URL}/seasons/start`, { year: this.year, name: this.name })
+      .subscribe();
+  }
+
+  saveResult(): void {
+    if (!this.matchId) return;
+    this.http
+      .put(`${API_URL}/matches/${this.matchId}/result`, {
+        team1Score: this.team1Score,
+        team2Score: this.team2Score,
+      })
+      .subscribe();
+  }
+
+  changeRole(id: string, role: string): void {
+    this.http
+      .put(`${API_URL}/users/${id}`, { role })
+      .subscribe(() => this.loadUsers());
+  }
+
+  deleteUser(id: string): void {
+    this.http.delete(`${API_URL}/users/${id}`).subscribe(() => this.loadUsers());
+  }
 }

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -1,6 +1,36 @@
 <div class="dashboard">
-  <h1>Willkommen, {{ username }}</h1>
-  <button (click)="logout()">Logout</button>
+  <div class="top-bar">
+    <span>Willkommen, {{ username }}</span>
+    <button (click)="logout()">Logout</button>
+  </div>
+
+  <section class="table-section" *ngIf="tableData.length">
+    <h2>Spielolympiade {{ seasonYear }}</h2>
+    <div class="table-wrapper">
+      <table class="season-table">
+        <thead>
+          <tr>
+            <th>Platz</th>
+            <th>Team</th>
+            <th>Spiele</th>
+            <th>Siege</th>
+            <th>Niederl.</th>
+            <th>Punkte</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let t of tableData; index as i">
+            <td>{{ i + 1 }}</td>
+            <td>{{ t.name }}</td>
+            <td>{{ t.spiele }}</td>
+            <td>{{ t.siege }}</td>
+            <td>{{ t.niederlagen }}</td>
+            <td>{{ t.points }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
   <section *ngIf="team">
     <h2>Dein Team</h2>
@@ -26,29 +56,4 @@
     </ul>
   </section>
 
-  <section>
-    <h2>Aktuelle Tabelle</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Platz</th>
-          <th>Team</th>
-          <th>Spiele</th>
-          <th>Siege</th>
-          <th>Niederl.</th>
-          <th>Punkte</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let t of allTeams; index as i">
-          <td>{{ i + 1 }}</td>
-          <td>{{ t.name }}</td>
-          <td>{{ t.spiele }}</td>
-          <td>{{ t.siege }}</td>
-          <td>{{ t.niederlagen }}</td>
-          <td>{{ t.points }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
 </div>

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.scss
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.scss
@@ -3,6 +3,19 @@
   margin: auto;
   padding: 1rem;
 
+  .top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #eee;
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+
+    button {
+      margin-left: 1rem;
+    }
+  }
+
   button {
     margin: 0.25rem;
   }
@@ -18,5 +31,33 @@
     li {
       margin-bottom: 0.5rem;
     }
+  }
+}
+
+.table-section {
+  margin-top: 2rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.season-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    text-align: center;
+  }
+
+  thead {
+    background-color: #f2f2f2;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: #fafafa;
   }
 }

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -26,6 +26,8 @@ export class DashboardComponent {
   allResults: any[] = [];
   todayResults: any[] = [];
   upcomingGames: any[] = [];
+  tableData: any[] = [];
+  seasonYear = '';
   activeGameDay = true; // optional: später dynamisch machen
 
   ngOnInit(): void {
@@ -35,9 +37,29 @@ export class DashboardComponent {
 
   loadMyTeam(): void {
     this.http.get<any>(`${API_URL}/users/my-team`).subscribe({
-      next: (res) => (this.team = res),
+      next: (res) => {
+        this.team = res;
+        this.seasonYear = this.extractYear(res.season);
+        this.loadTable();
+      },
       error: () => (this.team = null),
     });
+  }
+
+  loadTable(): void {
+    if (!this.team?.seasonId) return;
+    this.http
+      .get<any[]>(`${API_URL}/seasons/${this.team.seasonId}/table`)
+      .subscribe({
+        next: (data) => (this.tableData = data),
+        error: (err) => console.error('Fehler beim Laden der Tabelle', err),
+      });
+  }
+
+  extractYear(name: string | undefined): string {
+    if (!name) return '';
+    const match = name.match(/\d{4}/);
+    return match ? match[0] : name;
   }
 
   loadData(): void {

--- a/spielolympiade-frontend/src/app/pages/history/history.component.html
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.html
@@ -1,1 +1,31 @@
-<p>history works!</p>
+<div class="history">
+  <h2>Vergangene Spielolympiaden</h2>
+  <ul>
+    <li *ngFor="let s of seasons">
+      <button (click)="selectSeason(s.id)">{{ s.name }}</button>
+    </li>
+  </ul>
+
+  <section *ngIf="selected">
+    <h3>{{ selected.name }}</h3>
+
+    <h4>Teams</h4>
+    <ul>
+      <li *ngFor="let t of selected.teams">
+        {{ t.name }} - {{ getMemberNames(t.members) }}
+      </li>
+    </ul>
+
+    <h4>Ergebnisse</h4>
+    <ul>
+      <li *ngFor="let m of selected.tournaments[0]?.matches">
+        {{ m.game.name }}:
+        {{ m.team1Id }} vs {{ m.team2Id }} -
+        <ng-container *ngIf="m.results.length">
+          {{ m.results[0].score }} : {{ m.results[1].score }}
+        </ng-container>
+        <ng-container *ngIf="!m.results.length">noch offen</ng-container>
+      </li>
+    </ul>
+  </section>
+</div>

--- a/spielolympiade-frontend/src/app/pages/history/history.component.scss
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.scss
@@ -1,0 +1,7 @@
+ul {
+  list-style: none;
+  padding-left: 0;
+  li {
+    margin-bottom: 0.5rem;
+  }
+}

--- a/spielolympiade-frontend/src/app/pages/history/history.component.ts
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.ts
@@ -1,12 +1,40 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+
+const API_URL = environment.apiUrl;
 
 @Component({
   selector: 'app-history',
   standalone: true,
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './history.component.html',
-  styleUrl: './history.component.scss'
+  styleUrls: ['./history.component.scss']
 })
 export class HistoryComponent {
+  http = inject(HttpClient);
 
+  seasons: any[] = [];
+  selected: any = null;
+
+  ngOnInit(): void {
+    this.loadSeasons();
+  }
+
+  loadSeasons(): void {
+    this.http.get<any[]>(`${API_URL}/seasons`).subscribe((data) => {
+      this.seasons = data;
+    });
+  }
+
+  selectSeason(id: string): void {
+    this.http
+      .get<any>(`${API_URL}/seasons/${id}/history`)
+      .subscribe((s) => (this.selected = s));
+  }
+
+  getMemberNames(members: any[]): string {
+    return members.map((m: any) => m.user.name).join(', ');
+  }
 }

--- a/spielolympiade-frontend/src/app/pages/login/login.component.html
+++ b/spielolympiade-frontend/src/app/pages/login/login.component.html
@@ -10,6 +10,14 @@
       placeholder="Benutzername"
     />
 
+    <input
+      type="password"
+      name="password"
+      [(ngModel)]="password"
+      required
+      placeholder="Passwort"
+    />
+
     <button type="submit" [disabled]="!loginForm.form.valid">Login</button>
 
     <div *ngIf="error" class="error">{{ error }}</div>

--- a/spielolympiade-frontend/src/app/pages/login/login.component.ts
+++ b/spielolympiade-frontend/src/app/pages/login/login.component.ts
@@ -13,18 +13,19 @@ import { AuthService } from '../../core/auth.service';
 })
 export class LoginComponent {
   username: string = '';
+  password: string = '';
   error: string = '';
 
   constructor(private auth: AuthService, private router: Router) {}
 
   onSubmit(): void {
     this.error = '';
-    if (!this.username.trim()) {
-      this.error = 'Bitte Benutzernamen eingeben.';
+    if (!this.username.trim() || !this.password.trim()) {
+      this.error = 'Bitte Benutzernamen und Passwort eingeben.';
       return;
     }
 
-    this.auth.login(this.username).subscribe({
+    this.auth.login(this.username, this.password).subscribe({
       next: (res) => {
         this.auth.saveToken(res.token);
         this.router.navigate(['/dashboard']);


### PR DESCRIPTION
## Summary
- extend match routes for updating and deleting results
- expose season history data and start/finish endpoints
- add basic admin page for starting a season and entering results
- implement history page to browse past seasons
- add simple navigation bar across the app
- fix admin and history components
- add password protected login with user management

## Testing
- `npm test` *(backend: Missing script)*
- `npm test` in frontend *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e8d454a54832cae12b9d25d02030d