### PR TITLE
Add Codex environment config

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,7 @@
+image: node:18
+install:
+  - cd spielolympiade-backend && npm install && cd ..
+  - cd spielolympiade-frontend && npm install && cd ..
+  - npm install -g @angular/cli
+test:
+  - cd spielolympiade-frontend && npm test -- --watch=false --browsers=ChromeHeadless


### PR DESCRIPTION
## Summary
- add a `codex.yaml` to set up a Node.js environment and run Angular tests

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed66e0890832c90ec9576221a639a