### PR TITLE
Add toolbar with menu and basic login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.1.0",
+        "@angular/cdk": "^18.2.14",
         "@angular/common": "^18.1.0",
         "@angular/compiler": "^18.1.0",
         "@angular/core": "^18.1.0",
         "@angular/forms": "^18.1.0",
+        "@angular/material": "^18.2.14",
         "@angular/platform-browser": "^18.1.0",
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
@@ -347,6 +349,23 @@
         }
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "18.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.2.14.tgz",
+      "integrity": "sha512-vDyOh1lwjfVk9OqoroZAP8pf3xxKUvyl+TVR8nJxL4c5fOfUFkD7l94HaanqKSRwJcI2xiztuu92IVoHn8T33Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "18.1.4",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.1.4.tgz",
@@ -541,6 +560,24 @@
         "@angular/common": "18.1.4",
         "@angular/core": "18.1.4",
         "@angular/platform-browser": "18.1.4",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "18.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-18.2.14.tgz",
+      "integrity": "sha512-28pxzJP49Mymt664WnCtPkKeg7kXUsQKTKGf/Kl95rNTEdTJLbnlcc8wV0rT0yQNR7kXgpfBnG7h0ETLv/iu5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^18.0.0 || ^19.0.0",
+        "@angular/cdk": "18.2.14",
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
+        "@angular/forms": "^18.0.0 || ^19.0.0",
+        "@angular/platform-browser": "^18.0.0 || ^19.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -6881,7 +6918,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11031,7 +11068,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^18.1.0",
+    "@angular/cdk": "^18.2.14",
     "@angular/common": "^18.1.0",
     "@angular/compiler": "^18.1.0",
     "@angular/core": "^18.1.0",
     "@angular/forms": "^18.1.0",
+    "@angular/material": "^18.2.14",
     "@angular/platform-browser": "^18.1.0",
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,13 +1,3 @@
-.navbar {
-    margin-bottom: 20px;
-  }
-  
-  .navbar .btn {
-    margin-left: auto; /* Stellt sicher, dass der Button rechtsbündig ist */
-  }
-  
-  .navbar-nav svg {
-    max-height: 40px;
-    fill: currentColor; /* Nutze die Textfarbe */
-  }
-  
+.spacer{
+  flex:1 1 auto;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,13 +1,13 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Spielolympiade</a>
-    <div class="d-flex">
-      <a routerLink="/history" class="btn btn-secondary">Historie</a>
-      <a routerLink="/spiele" class="btn btn-primary">Spiele</a>
-      <a routerLink="/teams" class="btn btn-primary">Teamsverwaltung</a>
-      <a routerLink="/players" class="btn btn-primary">Spielerverwaltung</a> 
-    </div>
-  </div>
-</nav>
-
+<mat-toolbar color="primary" *ngIf="auth.isLoggedIn()">
+  <span>Willkommen zur Spielolympiade</span>
+  <span class="spacer"></span>
+  <button mat-icon-button [matMenuTriggerFor]="menu">
+    <mat-icon>more_vert</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-menu #menu="matMenu" *ngIf="auth.isLoggedIn()">
+  <button mat-menu-item routerLink="/history">Historie</button>
+  <button *ngIf="auth.isAdmin()" mat-menu-item routerLink="/players">Userverwaltung</button>
+  <button mat-menu-item (click)="logout()">Logout</button>
+</mat-menu>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,17 +1,24 @@
 import { Component } from '@angular/core';
-import { RouterLink, RouterOutlet } from '@angular/router';
-import { HomeComponent } from './home/home.component';
-import { PlayerManagementComponent } from './player-management/player-management.component';  // Importiere die Komponente
-import { FormsModule, NgModel } from '@angular/forms';
-import { NgClass } from '@angular/common';
+import { RouterLink, RouterOutlet, Router } from '@angular/router';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from './auth.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, HomeComponent, PlayerManagementComponent, RouterLink],  // Füge die Komponente hinzu
+  imports: [RouterOutlet, RouterLink, MatToolbarModule, MatIconModule, MatMenuModule, MatButtonModule],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
   title = 'spielolympiadeApp';
+  constructor(public auth: AuthService, private router: Router) {}
+
+  logout(): void {
+    this.auth.logout();
+    this.router.navigate(['/login']);
+  }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,11 +4,15 @@ import { PlayerManagementComponent } from './player-management/player-management
 import { TeamsManagmentComponent } from './teams-managment/teams-managment.component';
 import { SpieleComponent } from './spiele/spiele.component';
 import { HistoryComponent } from './history/history.component';
+import { LoginComponent } from './login/login.component';
+import { authGuard } from './auth.guard';
 
 export const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'players', component: PlayerManagementComponent },  // Route für die Spielerverwaltung
-  { path: 'teams', component: TeamsManagmentComponent },  // Route für die Spielerverwaltung
-  { path: 'spiele', component: SpieleComponent },  // Route für die Spielerverwaltung
-  { path: 'history', component: HistoryComponent }
+  { path: 'login', component: LoginComponent },
+  { path: '', component: HomeComponent, canActivate: [authGuard] },
+  { path: 'players', component: PlayerManagementComponent, canActivate: [authGuard] },
+  { path: 'teams', component: TeamsManagmentComponent, canActivate: [authGuard] },
+  { path: 'spiele', component: SpieleComponent, canActivate: [authGuard] },
+  { path: 'history', component: HistoryComponent, canActivate: [authGuard] },
+  { path: '**', redirectTo: '' }
 ];

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (!auth.isLoggedIn()) {
+    router.navigate(['/login']);
+    return false;
+  }
+  return true;
+};

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+
+interface User {
+  username: string;
+  role: 'admin' | 'user';
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private storageKey = 'authUser';
+
+  private users: Record<string, { password: string; role: 'admin' | 'user' }> = {
+    bj: { password: 'bj', role: 'admin' },
+    player: { password: 'player', role: 'user' }
+  };
+
+  constructor(private router: Router) {}
+
+  login(username: string, password: string): boolean {
+    const cred = this.users[username];
+    if (cred && cred.password === password) {
+      const user: User = { username, role: cred.role };
+      localStorage.setItem(this.storageKey, JSON.stringify(user));
+      return true;
+    }
+    return false;
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.storageKey);
+  }
+
+  getUser(): User | null {
+    const data = localStorage.getItem(this.storageKey);
+    return data ? (JSON.parse(data) as User) : null;
+  }
+
+  isLoggedIn(): boolean {
+    return !!this.getUser();
+  }
+
+  isAdmin(): boolean {
+    return this.getUser()?.role === 'admin';
+  }
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,4 +1,4 @@
-<div class="container mt-4">
+<div class="container mt-4" *ngIf="seasonActive; else waiting">
   <h1 class="text-center mb-4">Tabelle</h1>
   <table class="table table-hover table-bordered table-striped text-center mt-4">
     <thead class="table-dark">
@@ -19,56 +19,52 @@
         <td>{{ team.niederlagen }}</td>
         <td class="fw-bold">{{ team.points }}</td>
         <td>
-          <span *ngFor="let status of team.letzte5" 
-                class="badge me-1" 
-                [ngClass]="{
-                    'bg-success': status === 'S',
-                    'bg-warning text-dark': status === 'U',
-                    'bg-danger': status === 'N'
-                }">
+          <span *ngFor="let status of team.letzte5" class="badge me-1"
+                [ngClass]="{ 'bg-success': status === 'S',
+                            'bg-warning text-dark': status === 'U',
+                            'bg-danger': status === 'N'}">
             {{ status }}
-          </span>   
+          </span>
         </td>
       </tr>
     </tbody>
   </table>
 
-  <!-- Formular zum Eingeben eines neuen Results -->
-  <div class="mt-5">
+  <div class="mt-5" *ngIf="auth.isAdmin()">
     <h3>Neues Ergebnis eintragen</h3>
     <form (ngSubmit)="addResult()" class="form-inline">
       <select class="form-control" [(ngModel)]="newResult.gameId" name="gameId" required>
         <option value="" disabled selected hidden>Spiel auswählen</option>
         <option *ngFor="let game of games" [value]="game.id">{{ game.name }}</option>
       </select>
-  
       <select class="form-control" [(ngModel)]="newResult.team1Id" name="team1Id" required>
         <option value="" disabled selected hidden>Team 1 auswählen</option>
         <option *ngFor="let team of teams" [value]="team.id">{{ team.name }}</option>
       </select>
-  
       <select class="form-control" [(ngModel)]="newResult.team1Score" name="team1Score" required (change)="onScoreSelect('team1')">
         <option [value]="'1'">Gewinner</option>
         <option [value]="'0'">Verlierer</option>
       </select>
-  
       <label class="my">:</label>
-  
       <select class="form-control" [(ngModel)]="newResult.team2Score" name="team2Score" required (change)="onScoreSelect('team2')">
         <option [value]="'1'">Gewinner</option>
         <option [value]="'0'">Verlierer</option>
       </select>
-  
       <select class="form-control" [(ngModel)]="newResult.team2Id" name="team2Id" required>
         <option value="" disabled selected hidden>Team 2 auswählen</option>
         <option *ngFor="let team of teams" [value]="team.id">{{ team.name }}</option>
       </select>
-  
       <button type="submit" class="btn btn-primary"
               [disabled]="!newResult.gameId || !newResult.team1Id || !newResult.team2Id || newResult.team1Score === '' || newResult.team2Score === ''">
         Hinzufügen
       </button>
     </form>
   </div>
-  
 </div>
+
+<ng-template #waiting>
+  <div class="text-center mt-5">
+    <p>Die Spielolympiade beginnt bald. Schau dir solange die <a routerLink="/history">Historie</a> an.</p>
+    <button *ngIf="auth.isAdmin()" class="btn btn-primary" (click)="startSeason()">Neue Saison starten</button>
+  </div>
+</ng-template>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { TournamentService } from '../tournament.service';
+import { AuthService } from '../auth.service';
 import { Team } from '../models/team.model';
 import { Game } from '../models/game.model';
 import { Result } from '../models/result.model';
@@ -11,13 +13,15 @@ import { Result } from '../models/result.model';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css'],
   standalone: true,
-  imports: [CommonModule, FormsModule]  // Importiere hier CommonModule und FormsModule
+  imports: [CommonModule, FormsModule, RouterLink]
 })
 export class HomeComponent implements OnInit {
 
   teams: Team[] = [];
   games: Game[] = [];
   ergebnis: string[] = ['Gewinner', 'Verlierer'];
+
+  seasonActive = false;
 
   newResult: Result = {
     id: '',
@@ -28,11 +32,14 @@ export class HomeComponent implements OnInit {
     team2Score: '0'
   };
 
-  constructor(private tournamentService: TournamentService) { }
+  constructor(private tournamentService: TournamentService, public auth: AuthService) { }
 
   ngOnInit(): void {
-    this.loadTeams();
-    this.loadGames();
+    this.seasonActive = this.tournamentService.isSeasonActive();
+    if (this.seasonActive) {
+      this.loadTeams();
+      this.loadGames();
+    }
   }
 
  
@@ -64,7 +71,19 @@ export class HomeComponent implements OnInit {
       this.resetForm();
       this.ngOnInit();
     });
-}
+  }
+
+  startSeason(): void {
+    this.tournamentService.startSeason();
+    this.seasonActive = true;
+    this.loadTeams();
+    this.loadGames();
+  }
+
+  endSeason(): void {
+    this.tournamentService.endSeason();
+    this.seasonActive = false;
+  }
 
   
 

--- a/src/app/login/login.component.css
+++ b/src/app/login/login.component.css
@@ -1,0 +1,10 @@
+.login-container{
+  max-width:300px;
+  margin:40px auto;
+  display:flex;
+  flex-direction:column;
+}
+.login-container input{
+  margin-bottom:8px;
+}
+.error{color:red;margin-top:5px;}

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,0 +1,9 @@
+<div class="login-container">
+  <h2>Login</h2>
+  <form (ngSubmit)="login()" #loginForm="ngForm">
+    <input type="text" name="username" [(ngModel)]="username" placeholder="Benutzername" required>
+    <input type="password" name="password" [(ngModel)]="password" placeholder="Passwort" required>
+    <button type="submit">Anmelden</button>
+    <div *ngIf="invalid" class="error">Ungültige Daten</div>
+  </form>
+</div>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../auth.service';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './login.component.html'
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  invalid = false;
+  constructor(private auth: AuthService, private router: Router) {}
+
+  login(): void {
+    if (this.auth.login(this.username, this.password)) {
+      this.router.navigate(['/']);
+    } else {
+      this.invalid = true;
+    }
+  }
+}

--- a/src/app/tournament.service.ts
+++ b/src/app/tournament.service.ts
@@ -16,12 +16,26 @@ export class TournamentService {
   teams: Team[] = [];
   games: Game[] = [];
 
+  private seasonActiveKey = 'seasonActive';
+
   private apiUrl = 'http://localhost:3000';  // URL zu deinem JSON-Server
   private httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };
 
   constructor(private http: HttpClient) { }
+
+  isSeasonActive(): boolean {
+    return localStorage.getItem(this.seasonActiveKey) === 'true';
+  }
+
+  startSeason(): void {
+    localStorage.setItem(this.seasonActiveKey, 'true');
+  }
+
+  endSeason(): void {
+    localStorage.removeItem(this.seasonActiveKey);
+  }
 
   // Teams
   getTeams(): Observable<Team[]> {

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root> <!-- Dies ist der Einstiegspunkt für deine Angular-Anwendung -->

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
+@import '@angular/material/prebuilt-themes/indigo-pink.css';


### PR DESCRIPTION
## Summary
- introduce Angular Material toolbar with menu for Historie, Logout and admin Userverwaltung
- add simple login form and authentication service storing user role in localStorage
- protect routes with auth guard and display start-season message when no season is active
- enable basic season activation via TournamentService

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee9f31438832c995280df34cb699b