### PR TITLE
Hide finished season from dashboard

### DIFF
--- a/spielolympiade-backend/prisma/seed.ts
+++ b/spielolympiade-backend/prisma/seed.ts
@@ -14,6 +14,7 @@ async function main() {
       id: "season-2024",
       year: 2024,
       name: "Saison 2024",
+      finishedAt: new Date("2024-08-01"),
     },
   });
 

--- a/spielolympiade-backend/src/routes/seasons.ts
+++ b/spielolympiade-backend/src/routes/seasons.ts
@@ -39,9 +39,17 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
 
 router.get("/public/dashboard-data", async (_req, res) => {
   try {
-    const teams = await prisma.team.findMany();
+    const season = await prisma.season.findFirst({ where: { finishedAt: null } });
+
+    if (!season) {
+      return res.json({ teams: [], games: [], results: [] });
+    }
+
+    const teams = await prisma.team.findMany({ where: { seasonId: season.id } });
     const games = await prisma.game.findMany();
-    const results = await prisma.matchResult.findMany();
+    const results = await prisma.matchResult.findMany({
+      where: { match: { tournament: { seasonId: season.id } } },
+    });
 
     res.json({ teams, games, results });
   } catch (err) {

--- a/spielolympiade-backend/src/routes/users.ts
+++ b/spielolympiade-backend/src/routes/users.ts
@@ -32,6 +32,13 @@ router.get("/my-team", async (req: Request, res: Response): Promise<void> => {
     where: { username },
     include: {
       teamMemberships: {
+        where: {
+          team: {
+            season: {
+              finishedAt: null,
+            },
+          },
+        },
         include: {
           team: {
             include: {

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -1,8 +1,8 @@
 <div class="dashboard">
   <div class="info" *ngIf="!seasonActive">
     <p>
-      Die Spielolympiade beginnt bald.
-      <a routerLink="/history">Historie</a>
+      Die Spielolympiade beginnt bald!
+      <a routerLink="/history">Werfe doch ein Blick in die Historie!</a>
     </p>
     <button
       mat-raised-button


### PR DESCRIPTION
## Summary
- show a friendlier dashboard message linking to history
- mark the 2024 season as finished in the seed data
- only return teams from an active season for `/users/my-team`
- limit `/seasons/public/dashboard-data` to the active season

## Testing
- `npm run build` *(fails: Cannot find module '@prisma/client')*
- `npm test` in frontend *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efab134b4832c99b46d93e7c925ab