### PR TITLE
Add filter options for games on dashboard

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -75,20 +75,27 @@
   </section>
 
   <section *ngIf="activeGameDay">
-    <h2>Heutige Ergebnisse</h2>
+    <h2>Spiele</h2>
+    <div class="filters">
+      <button mat-raised-button (click)="setFilter('all')">Alle Spiele</button>
+      <button mat-raised-button (click)="setFilter('upcoming')">
+        Noch zu spielende Spiele
+      </button>
+      <mat-checkbox [(ngModel)]="onlyMine" (change)="applyFilters()"
+        >Nur meine Spiele</mat-checkbox
+      >
+    </div>
     <ul>
-      <li *ngFor="let r of todayResults">
-        {{ getGameName(r.gameId) }}: {{ getTeamName(r.team1Id) }} ({{
-          r.team1Score
-        }}) – {{ getTeamName(r.team2Id) }} ({{ r.team2Score }})
-      </li>
-    </ul>
-
-    <h2>Kommende Spiele deines Teams</h2>
-    <ul>
-      <li *ngFor="let r of upcomingGames">
-        {{ getGameName(r.gameId) }}: {{ getTeamName(r.team1Id) }} vs
-        {{ getTeamName(r.team2Id) }}
+      <li *ngFor="let r of filteredGames">
+        <ng-container *ngIf="r.team1Score || r.team2Score; else up">
+          {{ getGameName(r.gameId) }}:
+          {{ getTeamName(r.team1Id) }} ({{ r.team1Score }}) –
+          {{ getTeamName(r.team2Id) }} ({{ r.team2Score }})
+        </ng-container>
+        <ng-template #up>
+          {{ getGameName(r.gameId) }}:
+          {{ getTeamName(r.team1Id) }} vs {{ getTeamName(r.team2Id) }}
+        </ng-template>
       </li>
     </ul>
   </section>

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { HttpClient } from '@angular/common/http';
 import { AuthService } from '../../core/auth.service';
 import { environment } from '../../../environments/environment';
@@ -24,6 +25,7 @@ const API_URL = environment.apiUrl;
     MatFormFieldModule,
     MatInputModule,
     MatCardModule,
+    MatCheckboxModule,
     FormsModule,
   ],
   templateUrl: './dashboard.component.html',
@@ -55,6 +57,11 @@ export class DashboardComponent {
   team1Score = 0;
   team2Score = 0;
 
+  // Filter
+  filterMode: 'all' | 'upcoming' = 'upcoming';
+  onlyMine = false;
+  filteredGames: any[] = [];
+
   ngOnInit(): void {
     this.loadMyTeam();
     this.loadData();
@@ -67,6 +74,7 @@ export class DashboardComponent {
         this.seasonYear = this.extractYear(res.season);
         this.seasonActive = true;
         this.loadTable();
+        this.applyFilters();
       },
       error: () => {
         this.team = null;
@@ -114,11 +122,31 @@ export class DashboardComponent {
   }
 
   buildUpcoming(): void {
-    if (!this.team) return;
+    this.upcomingGames = this.allResults.filter(
+      (r) => !r.team1Score && !r.team2Score
+    );
+    this.applyFilters();
+  }
 
-    this.upcomingGames = this.allResults
-      .filter((r) => !r.team1Score && !r.team2Score)
-      .filter((r) => r.team1Id === this.team.id || r.team2Id === this.team.id);
+  setFilter(mode: 'all' | 'upcoming'): void {
+    this.filterMode = mode;
+    this.applyFilters();
+  }
+
+  applyFilters(): void {
+    let games = [...this.allResults];
+
+    if (this.filterMode === 'upcoming') {
+      games = games.filter((g) => !g.team1Score && !g.team2Score);
+    }
+
+    if (this.onlyMine && this.team) {
+      games = games.filter(
+        (g) => g.team1Id === this.team.id || g.team2Id === this.team.id
+      );
+    }
+
+    this.filteredGames = games;
   }
 
   getTeamName(id: string): string {


### PR DESCRIPTION
## Summary
- improve dashboard with ability to filter upcoming games
- allow filtering all or only remaining games and option to show only matches of the user's team

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_686efb4ad6f4832c825538f84d152336