### PR TITLE
Support active season filter

### DIFF
--- a/spielolympiade-backend/prisma/schema.prisma
+++ b/spielolympiade-backend/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Season {
   id       String  @id @default(uuid())
   year     Int
   name     String
+  isActive Boolean  @default(false)
   finishedAt DateTime?
 
   teams       Team[]

--- a/spielolympiade-backend/prisma/seed.ts
+++ b/spielolympiade-backend/prisma/seed.ts
@@ -14,6 +14,7 @@ async function main() {
       id: "season-2024",
       year: 2024,
       name: "Saison 2024",
+      isActive: false,
       finishedAt: new Date("2024-08-01"),
     },
   });

--- a/spielolympiade-backend/src/routes/seasons.ts
+++ b/spielolympiade-backend/src/routes/seasons.ts
@@ -39,7 +39,7 @@ router.get("/:id", async (req: Request, res: Response): Promise<void> => {
 
 router.get("/public/dashboard-data", async (_req, res) => {
   try {
-    const season = await prisma.season.findFirst({ where: { finishedAt: null } });
+    const season = await prisma.season.findFirst({ where: { isActive: true } });
 
     if (!season) {
       return res.json({ teams: [], games: [], results: [] });
@@ -175,7 +175,7 @@ router.post(
       return;
     }
 
-    const season = await prisma.season.create({ data: { year, name } });
+    const season = await prisma.season.create({ data: { year, name, isActive: true } });
     await prisma.tournament.create({
       data: { seasonId: season.id, system: "round_robin" },
     });
@@ -211,7 +211,7 @@ router.post(
       return;
     }
 
-    const season = await prisma.season.create({ data: { year, name } });
+    const season = await prisma.season.create({ data: { year, name, isActive: true } });
     const tournament = await prisma.tournament.create({
       data: { seasonId: season.id, system: system || "round_robin" },
     });
@@ -263,7 +263,7 @@ router.post(
 
     const season = await prisma.season.update({
       where: { id },
-      data: { finishedAt: new Date() },
+      data: { finishedAt: new Date(), isActive: false },
     });
 
     res.json(season);

--- a/spielolympiade-backend/src/routes/users.ts
+++ b/spielolympiade-backend/src/routes/users.ts
@@ -35,7 +35,7 @@ router.get("/my-team", async (req: Request, res: Response): Promise<void> => {
         where: {
           team: {
             season: {
-              finishedAt: null,
+              isActive: true,
             },
           },
         },


### PR DESCRIPTION
## Summary
- add `isActive` flag to season model
- include new flag in seed data
- return dashboard data only for active seasons
- mark newly created seasons active
- deactivate season on finish
- fetch active team using new flag

## Testing
- `npx prisma generate --no-install` *(fails: binaries.prisma.sh blocked)*
- `npm test` *(fails: missing test script)*
- `npm test` in frontend *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f74d998ac832cbc2f92a3d606a53c