### PR TITLE
Improve history UI

### DIFF
--- a/src/app/history/history.component.css
+++ b/src/app/history/history.component.css
@@ -1,0 +1,8 @@
+.list-group-item span:first-child {
+  flex: 1;
+}
+
+.list-group-item span.fw-bold {
+  flex: 2;
+  text-align: center;
+}

--- a/src/app/history/history.component.html
+++ b/src/app/history/history.component.html
@@ -1,42 +1,26 @@
 <div class="container mt-4">
   <h1 class="text-center mb-4">Historie</h1>
 
-  <!-- Filter für Spiele und Teams -->
   <div class="row mb-4">
     <div class="col-md-6">
-      <select id="gameFilter" class="form-control" [(ngModel)]="selectedGameId">
+      <select id="gameFilter" class="form-select" [(ngModel)]="selectedGameId">
         <option value="">Alle Spiele</option>
         <option *ngFor="let game of games" [value]="game.id">{{ game.name }}</option>
       </select>
     </div>
     <div class="col-md-6">
-      <select id="teamFilter" class="form-control" [(ngModel)]="selectedTeamId">
+      <select id="teamFilter" class="form-select" [(ngModel)]="selectedTeamId">
         <option value="">Alle Teams</option>
         <option *ngFor="let team of teams" [value]="team.id">{{ team.name }}</option>
       </select>
     </div>
   </div>
 
-  <table class="table table-hover table-bordered table-striped text-center mt-4">
-    <thead class="table-dark">
-      <tr>
-        <th>Spiel</th>
-        <th>Team 1</th>
-        <th>Team 2</th>
-        <th>Gewinner</th>
-        <th>Aktionen</th> <!-- Spalte für Aktionen hinzufügen -->
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let result of filteredResults">
-        <td>{{ getGameName(result.gameId) }}</td>
-        <td>{{ getTeamName(result.team1Id) }}</td>
-        <td>{{ getTeamName(result.team2Id) }}</td>
-        <td>{{ getWinner(result) }}</td>
-        <td>
-          <button class="btn btn-danger btn-sm" (click)="deleteResult(result.id)">Löschen</button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <ul class="list-group">
+    <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let result of filteredResults">
+      <span>{{ getGameName(result.gameId) }}</span>
+      <span class="fw-bold">{{ formatResult(result) }}</span>
+      <button class="btn btn-danger btn-sm" (click)="deleteResult(result.id)">Löschen</button>
+    </li>
+  </ul>
 </div>

--- a/src/app/history/history.component.ts
+++ b/src/app/history/history.component.ts
@@ -73,6 +73,12 @@ export class HistoryComponent implements OnInit {
       : this.getTeamName(result.team2Id);
   }
 
+  formatResult(result: Result): string {
+    const team1 = this.getTeamName(result.team1Id);
+    const team2 = this.getTeamName(result.team2Id);
+    return `${team1} ${result.team1Score}:${result.team2Score} ${team2}`;
+  }
+
   deleteResult(resultId: string): void {
     const resultToDelete = this.results.find(result => result.id === resultId);
     if (resultToDelete) {


### PR DESCRIPTION
## Summary
- display past results as list
- show results with team names in `Team1 1:0 Team2` format
- basic styling for list items

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_686f7bc82594832cae44c748d6a66882