### PR TITLE
Add user management and password change flow

### DIFF
--- a/db.json
+++ b/db.json
@@ -501,5 +501,8 @@
       "team1Score": "1",
       "team2Score": "0"
     }
+    ],
+  "users": [
+    {"id": "u1", "username": "admin", "password": "start", "role": "admin", "needsPasswordChange": false}
   ]
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light" *ngIf="auth.isLoggedIn()">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Spielolympiade</a>
     <button class="navbar-toggler" type="button" (click)="isNavbarCollapsed = !isNavbarCollapsed">
@@ -9,10 +9,11 @@
         <a routerLink="/history" class="btn btn-secondary me-2">Historie</a>
         <a routerLink="/spiele" class="btn btn-primary me-2">Spiele</a>
         <a routerLink="/teams" class="btn btn-primary me-2">Teamsverwaltung</a>
-        <a routerLink="/players" class="btn btn-primary">Spielerverwaltung</a>
+        <a routerLink="/players" class="btn btn-primary me-2">Spielerverwaltung</a>
+        <a *ngIf="auth.isAdmin()" routerLink="/users" class="btn btn-primary me-2">Userverwaltung</a>
+        <button class="btn btn-danger" (click)="logout()">Logout</button>
       </div>
     </div>
   </div>
 </nav>
-
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,18 +1,22 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
-import { HomeComponent } from './home/home.component';
-import { PlayerManagementComponent } from './player-management/player-management.component';  // Importiere die Komponente
-import { FormsModule, NgModel } from '@angular/forms';
 import { NgClass } from '@angular/common';
+import { AuthService } from './auth.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, HomeComponent, PlayerManagementComponent, RouterLink, NgClass],  // Füge die Komponente hinzu
+  imports: [RouterOutlet, RouterLink, NgClass],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
   title = 'spielolympiadeApp';
   isNavbarCollapsed = true;
+
+  constructor(public auth: AuthService) {}
+
+  logout(): void {
+    this.auth.logout();
+  }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,11 +4,19 @@ import { PlayerManagementComponent } from './player-management/player-management
 import { TeamsManagmentComponent } from './teams-managment/teams-managment.component';
 import { SpieleComponent } from './spiele/spiele.component';
 import { HistoryComponent } from './history/history.component';
+import { LoginComponent } from './login/login.component';
+import { ChangePasswordComponent } from './change-password/change-password.component';
+import { UserManagementComponent } from './user-management/user-management.component';
+import { authGuard } from './auth.guard';
 
 export const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'players', component: PlayerManagementComponent },  // Route für die Spielerverwaltung
-  { path: 'teams', component: TeamsManagmentComponent },  // Route für die Spielerverwaltung
-  { path: 'spiele', component: SpieleComponent },  // Route für die Spielerverwaltung
-  { path: 'history', component: HistoryComponent }
+  { path: 'login', component: LoginComponent },
+  { path: 'change-password', component: ChangePasswordComponent, canActivate: [authGuard] },
+  { path: '', component: HomeComponent, canActivate: [authGuard] },
+  { path: 'players', component: PlayerManagementComponent, canActivate: [authGuard] },
+  { path: 'teams', component: TeamsManagmentComponent, canActivate: [authGuard] },
+  { path: 'spiele', component: SpieleComponent, canActivate: [authGuard] },
+  { path: 'history', component: HistoryComponent, canActivate: [authGuard] },
+  { path: 'users', component: UserManagementComponent, canActivate: [authGuard] },
+  { path: '**', redirectTo: '' }
 ];

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (!auth.isLoggedIn()) {
+    router.navigate(['/login']);
+    return false;
+  }
+  return true;
+};

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { map, tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { User } from './models/user.model';
+import { UserService } from './user.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private storageKey = 'authUser';
+
+  constructor(private http: HttpClient, private router: Router, private userService: UserService) {}
+
+  login(username: string, password: string): Observable<'success' | 'change' | 'fail'> {
+    return this.http.get<User[]>(`http://localhost:3000/users?username=${username}`).pipe(
+      map(users => users[0]),
+      map(user => {
+        if (user && user.password === password) {
+          localStorage.setItem(this.storageKey, JSON.stringify(user));
+          return user.needsPasswordChange ? 'change' : 'success';
+        }
+        return 'fail';
+      })
+    );
+  }
+
+  changePassword(newPassword: string): Observable<User | null> {
+    const user = this.getUser();
+    if (!user) return of(null);
+    const updated: User = { ...user, password: newPassword, needsPasswordChange: false };
+    return this.userService.updateUser(updated).pipe(
+      tap(u => localStorage.setItem(this.storageKey, JSON.stringify(u)))
+    );
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.storageKey);
+    this.router.navigate(['/login']);
+  }
+
+  getUser(): User | null {
+    const data = localStorage.getItem(this.storageKey);
+    return data ? (JSON.parse(data) as User) : null;
+  }
+
+  isLoggedIn(): boolean {
+    return !!this.getUser();
+  }
+
+  isAdmin(): boolean {
+    return this.getUser()?.role === 'admin';
+  }
+}

--- a/src/app/change-password/change-password.component.css
+++ b/src/app/change-password/change-password.component.css
@@ -1,0 +1,6 @@
+.change-container {
+  width: 300px;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/app/change-password/change-password.component.html
+++ b/src/app/change-password/change-password.component.html
@@ -1,0 +1,7 @@
+<div class="change-container">
+  <h2>Passwort ändern</h2>
+  <form (ngSubmit)="change()" #f="ngForm">
+    <input type="password" name="newPassword" [(ngModel)]="newPassword" placeholder="Neues Passwort" required>
+    <button type="submit">Speichern</button>
+  </form>
+</div>

--- a/src/app/change-password/change-password.component.ts
+++ b/src/app/change-password/change-password.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../auth.service';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-change-password',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './change-password.component.html'
+})
+export class ChangePasswordComponent {
+  newPassword = '';
+
+  constructor(private auth: AuthService, private router: Router) {}
+
+  change(): void {
+    this.auth.changePassword(this.newPassword).subscribe(() => {
+      this.router.navigate(['/']);
+    });
+  }
+}

--- a/src/app/login/login.component.css
+++ b/src/app/login/login.component.css
@@ -1,0 +1,9 @@
+.login-container {
+  width: 300px;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+}
+.error {
+  color: red;
+}

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,0 +1,9 @@
+<div class="login-container">
+  <h2>Login</h2>
+  <form (ngSubmit)="login()" #loginForm="ngForm">
+    <input type="text" name="username" [(ngModel)]="username" placeholder="Benutzername" required>
+    <input type="password" name="password" [(ngModel)]="password" placeholder="Passwort" required>
+    <button type="submit">Anmelden</button>
+    <div *ngIf="invalid" class="error">Ungültige Daten</div>
+  </form>
+</div>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../auth.service';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './login.component.html'
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  invalid = false;
+
+  constructor(private auth: AuthService, private router: Router) {}
+
+  login(): void {
+    this.auth.login(this.username, this.password).subscribe(result => {
+      if (result === 'success') {
+        this.router.navigate(['/']);
+      } else if (result === 'change') {
+        this.router.navigate(['/change-password']);
+      } else {
+        this.invalid = true;
+      }
+    });
+  }
+}

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -1,0 +1,7 @@
+export interface User {
+  id: string;
+  username: string;
+  password: string;
+  role: 'admin' | 'user';
+  needsPasswordChange: boolean;
+}

--- a/src/app/user-management/user-management.component.css
+++ b/src/app/user-management/user-management.component.css
@@ -1,0 +1,12 @@
+.user-mgmt {
+  margin: 2rem;
+}
+table {
+  width: 100%;
+  margin-top: 1rem;
+  border-collapse: collapse;
+}
+th, td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}

--- a/src/app/user-management/user-management.component.html
+++ b/src/app/user-management/user-management.component.html
@@ -1,0 +1,19 @@
+<div class="user-mgmt">
+  <h2>Userverwaltung</h2>
+  <form (ngSubmit)="addUser()" #f="ngForm">
+    <input type="text" name="username" [(ngModel)]="newUsername" placeholder="Benutzername" required>
+    <select name="role" [(ngModel)]="newRole">
+      <option value="user">User</option>
+      <option value="admin">Admin</option>
+    </select>
+    <button type="submit">Erstellen</button>
+  </form>
+  <table>
+    <tr><th>Name</th><th>Rolle</th><th>Aktion</th></tr>
+    <tr *ngFor="let u of users">
+      <td>{{u.username}}</td>
+      <td>{{u.role}}</td>
+      <td><button (click)="resetPassword(u)">Passwort zurücksetzen</button></td>
+    </tr>
+  </table>
+</div>

--- a/src/app/user-management/user-management.component.ts
+++ b/src/app/user-management/user-management.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { UserService } from '../user.service';
+import { User } from '../models/user.model';
+
+@Component({
+  selector: 'app-user-management',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './user-management.component.html'
+})
+export class UserManagementComponent implements OnInit {
+  users: User[] = [];
+  newUsername = '';
+  newRole: 'admin' | 'user' = 'user';
+
+  constructor(private userService: UserService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.userService.getUsers().subscribe(u => (this.users = u));
+  }
+
+  addUser(): void {
+    const user: User = {
+      id: Math.random().toString(36).substr(2, 9),
+      username: this.newUsername,
+      password: this.userService.defaultPassword,
+      role: this.newRole,
+      needsPasswordChange: true
+    };
+    this.userService.addUser(user).subscribe(() => {
+      this.newUsername = '';
+      this.newRole = 'user';
+      this.load();
+    });
+  }
+
+  resetPassword(user: User): void {
+    const updated = { ...user, password: this.userService.defaultPassword, needsPasswordChange: true };
+    this.userService.updateUser(updated).subscribe(() => this.load());
+  }
+}

--- a/src/app/user.service.ts
+++ b/src/app/user.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { User } from './models/user.model';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private apiUrl = 'http://localhost:3000';
+  private httpOptions = {
+    headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+  };
+
+  defaultPassword = 'start';
+
+  constructor(private http: HttpClient) {}
+
+  getUsers(): Observable<User[]> {
+    return this.http.get<User[]>(`${this.apiUrl}/users`);
+  }
+
+  addUser(user: User): Observable<User> {
+    return this.http.post<User>(`${this.apiUrl}/users`, user, this.httpOptions);
+  }
+
+  updateUser(user: User): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/users/${user.id}`, user, this.httpOptions);
+  }
+}


### PR DESCRIPTION
## Summary
- add Login component with redirect for default password change
- add ChangePassword component
- add UserManagement admin view and UserService
- implement AuthService with basic storage and HTTP calls
- protect routes via auth guard and update navigation
- seed an admin user in db.json

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7c920214832c98243dfeb0e655b9