### PR TITLE
Enhance history view

### DIFF
--- a/spielolympiade-backend/src/routes/seasons.ts
+++ b/spielolympiade-backend/src/routes/seasons.ts
@@ -72,7 +72,15 @@ router.get(
         },
         tournaments: {
           include: {
-            matches: { include: { game: true, results: true, winner: true } },
+            matches: {
+              include: {
+                game: true,
+                results: true,
+                winner: true,
+                team1: true,
+                team2: true,
+              },
+            },
           },
         },
       },

--- a/spielolympiade-frontend/src/app/pages/history/history.component.html
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.html
@@ -17,15 +17,42 @@
     </ul>
 
     <h4>Ergebnisse</h4>
-    <ul>
-      <li *ngFor="let m of selected.tournaments[0]?.matches">
-        {{ m.game.name }}:
-        {{ m.team1Id }} vs {{ m.team2Id }} -
-        <ng-container *ngIf="m.results.length">
-          {{ m.results[0].score }} : {{ m.results[1].score }}
-        </ng-container>
-        <ng-container *ngIf="!m.results.length">noch offen</ng-container>
-      </li>
-    </ul>
+    <div class="filters">
+      <label>
+        Spiel:
+        <select [(ngModel)]="gameFilter">
+          <option value="all">Alle</option>
+          <option *ngFor="let g of gameOptions" [value]="g.id">{{ g.name }}</option>
+        </select>
+      </label>
+      <label>
+        Team:
+        <select [(ngModel)]="teamFilter">
+          <option value="all">Alle</option>
+          <option *ngFor="let t of teamOptions" [value]="t.id">{{ t.name }}</option>
+        </select>
+      </label>
+    </div>
+    <table class="result-table">
+      <thead>
+        <tr>
+          <th>Spiel</th>
+          <th>Match</th>
+          <th>Ergebnis</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let m of filteredMatches">
+          <td>{{ m.game.name }}</td>
+          <td>{{ m.team1.name }} vs {{ m.team2.name }}</td>
+          <td>
+            <ng-container *ngIf="m.results.length; else open">
+              {{ m.team1.name }} {{ m.results[0].score }} : {{ m.results[1].score }} {{ m.team2.name }}
+            </ng-container>
+            <ng-template #open>noch offen</ng-template>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </div>

--- a/spielolympiade-frontend/src/app/pages/history/history.component.scss
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.scss
@@ -5,3 +5,27 @@ ul {
     margin-bottom: 0.5rem;
   }
 }
+
+.filters {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 1rem;
+  label {
+    display: flex;
+    flex-direction: column;
+    font-weight: bold;
+  }
+}
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+  th,
+  td {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid #ccc;
+  }
+  th {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- include match teams in `GET /seasons/:id/history`
- show team names in history page
- add dropdown filters for game and team
- format results as table

## Testing
- `npm test --silent -- --watch=false` *(fails: authGuard/auth spec errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f81592594832cbe96e2520bfe80a9