### PR TITLE
Add improved season setup and match editing

### DIFF
--- a/spielolympiade-frontend/src/app/app.component.html
+++ b/spielolympiade-frontend/src/app/app.component.html
@@ -9,7 +9,6 @@
 <mat-menu #menu="matMenu">
   <button mat-menu-item routerLink="/history">Historie</button>
   <button mat-menu-item routerLink="/admin" *ngIf="auth.getUser()?.role === 'admin'">Userverwaltung</button>
-  <button mat-menu-item routerLink="/start-season" *ngIf="auth.getUser()?.role === 'admin'">Neue Saison</button>
   <button mat-menu-item (click)="logout()">Logout</button>
 </mat-menu>
 

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -8,20 +8,10 @@
       mat-raised-button
       color="accent"
       *ngIf="auth.getUser()?.role === 'admin'"
-      (click)="toggleStart()"
+      routerLink="/start-season"
     >
       Neue Saison starten
     </button>
-
-    <div *ngIf="showStartForm" class="start-form">
-      <mat-form-field>
-        <input matInput type="number" [(ngModel)]="newYear" placeholder="Jahr" />
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput [(ngModel)]="newName" placeholder="Name" />
-      </mat-form-field>
-      <button mat-raised-button color="primary" (click)="startSeason()">Starten</button>
-    </div>
   </div>
 
   <ng-container *ngIf="seasonActive">
@@ -77,42 +67,27 @@
   <section *ngIf="activeGameDay">
     <h2>Spiele</h2>
     <div class="filters">
-      <button mat-raised-button (click)="setFilter('all')">Alle Spiele</button>
-      <button mat-raised-button (click)="setFilter('upcoming')">
-        Noch zu spielende Spiele
-      </button>
-      <mat-checkbox [(ngModel)]="onlyMine" (change)="applyFilters()"
-        >Nur meine Spiele</mat-checkbox
-      >
+      <button mat-raised-button (click)="setFilter('all')">Alle Begegnungen</button>
+      <button mat-raised-button (click)="setFilter('open')">Offen</button>
+      <button mat-raised-button (click)="setFilter('played')">Gespielt</button>
+      <mat-checkbox [(ngModel)]="onlyMine" (change)="applyFilters()">Nur meine Spiele</mat-checkbox>
     </div>
     <ul>
       <li *ngFor="let r of filteredGames">
-        <ng-container *ngIf="r.team1Score || r.team2Score; else up">
-          {{ getGameName(r.gameId) }}:
-          {{ getTeamName(r.team1Id) }} ({{ r.team1Score }}) –
-          {{ getTeamName(r.team2Id) }} ({{ r.team2Score }})
-        </ng-container>
-        <ng-template #up>
-          {{ getGameName(r.gameId) }}:
-          {{ getTeamName(r.team1Id) }} vs {{ getTeamName(r.team2Id) }}
-        </ng-template>
+        {{ getGameName(r.gameId) }} |
+        {{ getTeamName(r.team1Id) }}
+        <input *ngIf="auth.getUser()?.role === 'admin'" type="number" [(ngModel)]="r.team1Score" style="width:40px" />
+        <span *ngIf="auth.getUser()?.role !== 'admin'">({{ r.team1Score ?? '-' }})</span>
+        –
+        {{ getTeamName(r.team2Id) }}
+        <input *ngIf="auth.getUser()?.role === 'admin'" type="number" [(ngModel)]="r.team2Score" style="width:40px" />
+        <span *ngIf="auth.getUser()?.role !== 'admin'">({{ r.team2Score ?? '-' }})</span>
+        <button *ngIf="auth.getUser()?.role === 'admin'" mat-button color="accent" (click)="saveResultFor(r)">Speichern</button>
       </li>
     </ul>
   </section>
 
-  <div class="result-form" *ngIf="auth.getUser()?.role === 'admin'">
-    <h3>Ergebnis eintragen</h3>
-    <mat-form-field>
-      <input matInput [(ngModel)]="matchId" placeholder="Match ID" />
-    </mat-form-field>
-    <mat-form-field>
-      <input matInput type="number" [(ngModel)]="team1Score" placeholder="Team1 Score" />
-    </mat-form-field>
-    <mat-form-field>
-      <input matInput type="number" [(ngModel)]="team2Score" placeholder="Team2 Score" />
-    </mat-form-field>
-    <button mat-raised-button color="accent" (click)="saveResult()">Speichern</button>
-  </div>
+
 
   </ng-container>
 </div>

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.html
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.html
@@ -16,7 +16,8 @@
     <h3>2. Teams erstellen</h3>
     <button mat-button (click)="generateTeams()">Zufallsgenerator</button>
     <div *ngFor="let t of teams">
-      {{ t.name }} - {{ t.playerIds.map(getPlayerName).join(', ') }}
+      <input [(ngModel)]="t.name" placeholder="Teamname" /> -
+      {{ t.playerIds.map(getPlayerName).join(', ') }}
     </div>
     <h4>Manuell hinzufügen</h4>
     <input [(ngModel)]="newTeamName" placeholder="Teamname" />

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.ts
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.ts
@@ -74,9 +74,16 @@ export class StartSeasonComponent {
     for (let i = 0; i < shuffled.length; i += 2) {
       const members = shuffled.slice(i, i + 2);
       this.teams.push({
-        name: 'Team ' + (i / 2 + 1),
+        name: 'Team ' + (this.teams.length + 1),
         playerIds: members.map((m) => m.id),
       });
+    }
+    if (
+      this.teams.length > 1 &&
+      this.teams[this.teams.length - 1].playerIds.length === 1
+    ) {
+      const last = this.teams.pop();
+      this.teams[this.teams.length - 1].playerIds.push(last!.playerIds[0]);
     }
   }
 


### PR DESCRIPTION
## Summary
- remove toolbar link to start season
- allow admin to create season from dashboard via dedicated page
- support editing team names and smarter team generator
- filter matches by state and enter results inline

## Testing
- `npm test` *(fails: ng not found)*
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_686f81874454832c91096a68ec952cfd