### PR TITLE
Improve start season page

### DIFF
--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.html
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.html
@@ -3,28 +3,38 @@
 
   <div *ngIf="step === 1">
     <h3>1. Spieler auswählen</h3>
-    <div *ngFor="let p of players">
-      <label>
-        <input type="checkbox" (change)="togglePlayer(p, $event)" />
+    <mat-selection-list [(ngModel)]="selectedPlayers">
+      <mat-list-option *ngFor="let p of players" [value]="p">
         {{ p.name }}
-      </label>
-    </div>
+      </mat-list-option>
+    </mat-selection-list>
     <button mat-raised-button color="primary" (click)="next()">Weiter</button>
   </div>
 
   <div *ngIf="step === 2">
     <h3>2. Teams erstellen</h3>
     <button mat-button (click)="generateTeams()">Zufallsgenerator</button>
-    <div *ngFor="let t of teams">
-      <input [(ngModel)]="t.name" placeholder="Teamname" /> -
-      {{ t.playerIds.map(getPlayerName).join(', ') }}
+    <div *ngFor="let t of teams; let i = index" class="team-row">
+      <mat-form-field>
+        <input matInput [(ngModel)]="t.name" placeholder="Teamname" />
+      </mat-form-field>
+      <span>{{ t.playerIds.map(getPlayerName).join(', ') }}</span>
+      <button mat-icon-button color="warn" (click)="removeTeam(i)">
+        <mat-icon>delete</mat-icon>
+      </button>
     </div>
     <h4>Manuell hinzufügen</h4>
-    <input [(ngModel)]="newTeamName" placeholder="Teamname" />
-    <select multiple [(ngModel)]="newTeamPlayers">
-      <option *ngFor="let p of players" [value]="p.id">{{ p.name }}</option>
-    </select>
-    <button mat-button (click)="addTeam()">Hinzufügen</button>
+    <mat-form-field>
+      <input matInput [(ngModel)]="newTeamName" placeholder="Teamname" />
+    </mat-form-field>
+    <mat-form-field class="players-select">
+      <mat-select multiple [(ngModel)]="newTeamPlayers" placeholder="Spieler">
+        <mat-option *ngFor="let p of selectedPlayers" [value]="p.id">
+          {{ p.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button mat-raised-button color="accent" (click)="addTeam()">Hinzufügen</button>
     <br />
     <button mat-raised-button (click)="prev()">Zurück</button>
     <button mat-raised-button color="primary" (click)="next()">Weiter</button>
@@ -33,17 +43,16 @@
   <div *ngIf="step === 3">
     <h3>3. Spiele auswählen</h3>
     <div *ngFor="let g of games">
-      <label>
-        <input type="checkbox" (change)="toggleGame(g.id, $event)" />
-        {{ g.name }}
-      </label>
+      <mat-checkbox (change)="toggleGame(g.id, $event)">{{ g.name }}</mat-checkbox>
     </div>
     <h3>Turnierform</h3>
-    <select [(ngModel)]="system">
-      <option value="round_robin">Jeder gegen Jeden</option>
-      <option value="single_elim">K.O.</option>
-      <option value="double_elim">Double K.O.</option>
-    </select>
+    <mat-form-field>
+      <mat-select [(ngModel)]="system" placeholder="System">
+        <mat-option value="round_robin">Jeder gegen Jeden</mat-option>
+        <mat-option value="single_elim">K.O.</mat-option>
+        <mat-option value="double_elim">Double K.O.</mat-option>
+      </mat-select>
+    </mat-form-field>
     <br />
     <button mat-raised-button (click)="prev()">Zurück</button>
     <button mat-raised-button color="primary" (click)="next()">Weiter</button>

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.scss
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.scss
@@ -1,3 +1,24 @@
 .start-season {
+  max-width: 800px;
+  margin: auto;
   padding: 1rem;
+
+  .team-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  .players-select {
+    min-width: 200px;
+  }
+
+  button {
+    margin-top: 0.5rem;
+  }
 }

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.ts
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.ts
@@ -1,6 +1,13 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCheckboxModule, MatCheckboxChange } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatListModule } from '@angular/material/list';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
@@ -10,7 +17,17 @@ const API_URL = environment.apiUrl;
 @Component({
   selector: 'app-start-season',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatListModule,
+    MatIconModule,
+  ],
   templateUrl: './start-season.component.html',
   styleUrls: ['./start-season.component.scss']
 })
@@ -41,11 +58,6 @@ export class StartSeasonComponent {
       .subscribe((d) => (this.games = d.games));
   }
 
-  togglePlayer(p: any, event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
-    if (checked) this.selectedPlayers.push(p);
-    else this.selectedPlayers = this.selectedPlayers.filter((x) => x.id !== p.id);
-  }
 
   getPlayerName(id: string): string {
     return this.players.find((p) => p.id === id)?.name ?? id;
@@ -55,8 +67,8 @@ export class StartSeasonComponent {
     return this.games.find((g) => g.id === id)?.name ?? id;
   }
 
-  toggleGame(id: string, event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
+  toggleGame(id: string, event: MatCheckboxChange): void {
+    const checked = event.checked;
     if (checked) this.selectedGameIds.push(id);
     else this.selectedGameIds = this.selectedGameIds.filter((g) => g !== id);
   }
@@ -66,6 +78,10 @@ export class StartSeasonComponent {
     this.teams.push({ name: this.newTeamName, playerIds: [...this.newTeamPlayers] });
     this.newTeamName = '';
     this.newTeamPlayers = [];
+  }
+
+  removeTeam(index: number): void {
+    this.teams.splice(index, 1);
   }
 
   generateTeams(): void {


### PR DESCRIPTION
## Summary
- use Angular Material on the start season page
- implement team removal and better form layout
- restyle the page with simple SCSS tweaks

## Testing
- `npx ng build --configuration development --no-progress`
- `npm test --silent -- --no-watch --browsers=ChromeHeadless` *(fails: auth.guard, user.model, app.component specs)*

------
https://chatgpt.com/codex/tasks/task_e_68710c237918832c82fcfc66e11c08a4