### PR TITLE
Improve start season page

### DIFF
--- a/spielolympiade-backend/prisma/schema.prisma
+++ b/spielolympiade-backend/prisma/schema.prisma
@@ -88,6 +88,9 @@ model Match {
   scheduledAt  DateTime?
   playedAt     DateTime?
 
+  stage        MatchStage @default(group)
+  groupName    String?
+
   results      MatchResult[]
 }
 
@@ -110,4 +113,12 @@ enum TournamentSystem {
   round_robin
   single_elim
   double_elim
+  group_ko
+}
+
+enum MatchStage {
+  group
+  semi_final
+  final
+  third_place
 }

--- a/spielolympiade-backend/src/index.ts
+++ b/spielolympiade-backend/src/index.ts
@@ -7,6 +7,8 @@ import userRoutes from "./routes/users";
 import teamRoutes from "./routes/teams";
 import matchRoutes from "./routes/matches";
 import seasonRoutes from "./routes/seasons";
+import gameRoutes from "./routes/games";
+import tournamentRoutes from "./routes/tournaments";
 import { authenticateToken } from "./middleware/auth";
 
 dotenv.config();
@@ -20,6 +22,8 @@ app.use("/users", authenticateToken, userRoutes);
 app.use("/teams", authenticateToken, teamRoutes);
 app.use("/matches", authenticateToken, matchRoutes);
 app.use("/seasons", authenticateToken, seasonRoutes);
+app.use("/games", authenticateToken, gameRoutes);
+app.use("/tournaments", authenticateToken, tournamentRoutes);
 
 // ✅ Typen explizit angeben
 app.get("/", (req: Request, res: Response): void => {

--- a/spielolympiade-backend/src/routes/games.ts
+++ b/spielolympiade-backend/src/routes/games.ts
@@ -1,0 +1,13 @@
+import express, { Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+// GET /games - list all games
+router.get("/", async (_req: Request, res: Response): Promise<void> => {
+  const games = await prisma.game.findMany();
+  res.json(games);
+});
+
+export default router;

--- a/spielolympiade-backend/src/routes/tournaments.ts
+++ b/spielolympiade-backend/src/routes/tournaments.ts
@@ -1,0 +1,111 @@
+import express, { Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
+import { authorizeRole } from "../middleware/auth";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+// POST /tournaments/:id/start-ko-phase - generate KO matches after group stage
+router.post(
+  "/:id/start-ko-phase",
+  authorizeRole("admin"),
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const tournament = await prisma.tournament.findUnique({
+      where: { id },
+      include: { matches: { include: { results: true } } },
+    });
+    if (!tournament) {
+      res.status(404).json({ error: "Turnier nicht gefunden" });
+      return;
+    }
+
+    if (tournament.system !== "group_ko") {
+      res.status(400).json({ error: "Nur für Gruppen-KO Turniere" });
+      return;
+    }
+
+    const games = [
+      ...new Set(tournament.matches.map((m: any) => m.gameId)),
+    ] as string[];
+
+    for (const gameId of games) {
+      const groupMatches = tournament.matches.filter(
+        (m: any) => m.gameId === gameId && m.stage === "group"
+      );
+      const groups: Record<string, any[]> = {};
+      for (const m of groupMatches) {
+        if (!m.groupName) continue;
+        groups[m.groupName] = groups[m.groupName] || [];
+        if (!groups[m.groupName].includes(m.team1Id))
+          groups[m.groupName].push(m.team1Id);
+        if (!groups[m.groupName].includes(m.team2Id))
+          groups[m.groupName].push(m.team2Id);
+      }
+
+      const standings: Record<string, { teamId: string; points: number }[]> = {};
+      for (const m of groupMatches) {
+        if (!m.winnerId) {
+          res.status(400).json({ error: "Gruppenspiele noch nicht abgeschlossen" });
+          return;
+        }
+        const group = m.groupName as string;
+        standings[group] = standings[group] || groups[group].map((t) => ({ teamId: t, points: 0 }));
+        const entry = standings[group].find((s) => s.teamId === m.winnerId);
+        if (entry) entry.points += 1;
+      }
+
+      for (const group of Object.keys(standings)) {
+        standings[group].sort((a, b) => b.points - a.points);
+      }
+
+      const semi1Team1 = standings["A"][0].teamId;
+      const semi1Team2 = standings["B"][1].teamId;
+      const semi2Team1 = standings["B"][0].teamId;
+      const semi2Team2 = standings["A"][1].teamId;
+
+      const semi1 = await prisma.match.create({
+        data: {
+          tournamentId: tournament.id,
+          gameId,
+          team1Id: semi1Team1,
+          team2Id: semi1Team2,
+          stage: "semi_final",
+        },
+      });
+      const semi2 = await prisma.match.create({
+        data: {
+          tournamentId: tournament.id,
+          gameId,
+          team1Id: semi2Team1,
+          team2Id: semi2Team2,
+          stage: "semi_final",
+        },
+      });
+
+      await prisma.match.create({
+        data: {
+          tournamentId: tournament.id,
+          gameId,
+          team1Id: semi1.winnerId || semi1Team1,
+          team2Id: semi2.winnerId || semi2Team1,
+          stage: "final",
+        },
+      });
+
+      await prisma.match.create({
+        data: {
+          tournamentId: tournament.id,
+          gameId,
+          team1Id: semi1.winnerId ? semi2Team2 : semi1Team1,
+          team2Id: semi2.winnerId ? semi1Team2 : semi2Team1,
+          stage: "third_place",
+        },
+      });
+    }
+
+    res.json({ success: true });
+  }
+);
+
+export default router;

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -15,8 +15,23 @@
   </div>
 
   <ng-container *ngIf="seasonActive">
+  <button
+      mat-raised-button
+      color="warn"
+      *ngIf="auth.getUser()?.role === 'admin'"
+      (click)="deleteSeason()"
+    >Saison löschen</button>
 
-  <section class="table-section" *ngIf="tableData.length">
+  <div class="view-switch" *ngIf="tournamentSystem === 'group_ko'">
+    <mat-form-field>
+      <mat-select [(ngModel)]="viewMode">
+        <mat-option value="overall">Gesamtübersicht</mat-option>
+        <mat-option *ngFor="let g of allGames" [value]="g.id">{{ g.name }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <section class="table-section" *ngIf="tableData.length && (viewMode === 'overall' || tournamentSystem !== 'group_ko')">
     <mat-card class="table-card">
       <mat-card-title>Spielolympiade {{ seasonYear }}</mat-card-title>
       <div class="table-wrapper">
@@ -57,6 +72,33 @@
         </table>
       </div>
     </mat-card>
+  </section>
+
+  <section *ngIf="tournamentSystem === 'group_ko' && viewMode !== 'overall'">
+    <h3>{{ getGameName(viewMode) }} - Gruppen</h3>
+    <div class="groups" *ngFor="let group of ['A','B']">
+      <h4>Gruppe {{ group }}</h4>
+      <table class="result-table">
+        <tr>
+          <th>Team</th>
+          <th>Punkte</th>
+        </tr>
+        <tr *ngFor="let row of groupStandings(viewMode)[group]">
+          <td>{{ getTeamName(row.teamId) }}</td>
+          <td>{{ row.points }}</td>
+        </tr>
+      </table>
+    </div>
+    <h4>K.O.-Phase</h4>
+    <ul>
+      <li *ngFor="let m of allMatches.filter(m => m.gameId===viewMode && m.stage !== 'group')">
+        {{ getTeamName(m.team1Id) }} vs {{ getTeamName(m.team2Id) }} -
+        <ng-container *ngIf="m.team1Score != null && m.team2Score != null; else open">
+          {{ m.team1Score }} : {{ m.team2Score }}
+        </ng-container>
+        <ng-template #open>noch offen</ng-template>
+      </li>
+    </ul>
   </section>
 
   <section *ngIf="team">

--- a/spielolympiade-frontend/src/app/pages/history/history.component.html
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.html
@@ -3,6 +3,9 @@
   <ul>
     <li *ngFor="let s of seasons">
       <button (click)="selectSeason(s.id)">{{ s.name }}</button>
+      <button *ngIf="auth.getUser()?.role === 'admin'" (click)="deleteSeason(s.id)" mat-icon-button>
+        <mat-icon>delete</mat-icon>
+      </button>
     </li>
   </ul>
 

--- a/spielolympiade-frontend/src/app/pages/history/history.component.ts
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 
@@ -9,7 +10,7 @@ const API_URL = environment.apiUrl;
 @Component({
   selector: 'app-history',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, MatIconModule],
   templateUrl: './history.component.html',
   styleUrls: ['./history.component.scss']
 })
@@ -64,5 +65,12 @@ export class HistoryComponent {
       );
     }
     return matches;
+  }
+
+  deleteSeason(id: string): void {
+    this.http.delete(`${API_URL}/seasons/${id}`).subscribe(() => {
+      this.selected = null;
+      this.loadSeasons();
+    });
   }
 }

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.html
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.html
@@ -3,28 +3,38 @@
 
   <div *ngIf="step === 1">
     <h3>1. Spieler auswählen</h3>
-    <div *ngFor="let p of players">
-      <label>
-        <input type="checkbox" (change)="togglePlayer(p, $event)" />
+    <mat-selection-list [(ngModel)]="selectedPlayers">
+      <mat-list-option *ngFor="let p of players" [value]="p">
         {{ p.name }}
-      </label>
-    </div>
+      </mat-list-option>
+    </mat-selection-list>
     <button mat-raised-button color="primary" (click)="next()">Weiter</button>
   </div>
 
   <div *ngIf="step === 2">
     <h3>2. Teams erstellen</h3>
     <button mat-button (click)="generateTeams()">Zufallsgenerator</button>
-    <div *ngFor="let t of teams">
-      <input [(ngModel)]="t.name" placeholder="Teamname" /> -
-      {{ t.playerIds.map(getPlayerName).join(', ') }}
+    <div *ngFor="let t of teams; let i = index" class="team-row">
+      <mat-form-field>
+        <input matInput [(ngModel)]="t.name" placeholder="Teamname" />
+      </mat-form-field>
+      <span>{{ formatPlayers(t.playerIds) }}</span>
+      <button mat-icon-button color="warn" (click)="removeTeam(i)">
+        <mat-icon>delete</mat-icon>
+      </button>
     </div>
     <h4>Manuell hinzufügen</h4>
-    <input [(ngModel)]="newTeamName" placeholder="Teamname" />
-    <select multiple [(ngModel)]="newTeamPlayers">
-      <option *ngFor="let p of players" [value]="p.id">{{ p.name }}</option>
-    </select>
-    <button mat-button (click)="addTeam()">Hinzufügen</button>
+    <mat-form-field>
+      <input matInput [(ngModel)]="newTeamName" placeholder="Teamname" />
+    </mat-form-field>
+    <mat-form-field class="players-select">
+      <mat-select multiple [(ngModel)]="newTeamPlayers" placeholder="Spieler">
+        <mat-option *ngFor="let p of availablePlayers()" [value]="p.id">
+          {{ p.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button mat-raised-button color="accent" (click)="addTeam()">Hinzufügen</button>
     <br />
     <button mat-raised-button (click)="prev()">Zurück</button>
     <button mat-raised-button color="primary" (click)="next()">Weiter</button>
@@ -33,17 +43,22 @@
   <div *ngIf="step === 3">
     <h3>3. Spiele auswählen</h3>
     <div *ngFor="let g of games">
-      <label>
-        <input type="checkbox" (change)="toggleGame(g.id, $event)" />
-        {{ g.name }}
-      </label>
+      <mat-checkbox (change)="toggleGame(g.id, $event)">{{ g.name }}</mat-checkbox>
     </div>
-    <h3>Turnierform</h3>
-    <select [(ngModel)]="system">
-      <option value="round_robin">Jeder gegen Jeden</option>
-      <option value="single_elim">K.O.</option>
-      <option value="double_elim">Double K.O.</option>
-    </select>
+    <h3>Turnierform
+      <button mat-icon-button (click)="openInfo()" aria-label="Info">
+        <mat-icon fontIcon="info"></mat-icon>
+      </button>
+    </h3>
+    <mat-form-field>
+      <mat-select [(ngModel)]="system" placeholder="System">
+        <mat-option value="round_robin">Jeder gegen Jeden</mat-option>
+        <mat-option value="single_elim">K.O.</mat-option>
+        <mat-option value="double_elim">Double K.O.</mat-option>
+        <mat-option value="group_ko">Gruppenphase + K.O.</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <p class="beer-info">Bierinfo: {{ getBeerInfo() }}</p>
     <br />
     <button mat-raised-button (click)="prev()">Zurück</button>
     <button mat-raised-button color="primary" (click)="next()">Weiter</button>
@@ -54,7 +69,7 @@
     <p>{{ name }} ({{ year }})</p>
     <ul>
       <li *ngFor="let t of teams">
-        {{ t.name }} - {{ t.playerIds.map(getPlayerName).join(', ') }}
+        {{ t.name }} - {{ formatPlayers(t.playerIds) }}
       </li>
     </ul>
     <p>Spiele: {{ selectedGameIds.map(getGameName).join(', ') }}</p>
@@ -63,3 +78,25 @@
     <button mat-raised-button color="accent" (click)="start()">Spielolympiade starten</button>
   </div>
 </div>
+
+<ng-template #systemInfo>
+  <h2 mat-dialog-title>Information zur Turnierform</h2>
+  <mat-dialog-content>
+    <p *ngIf="system === 'round_robin'">
+      Beim Jeder-gegen-Jeden spielt jedes Team gegen alle anderen Teams.
+    </p>
+    <p *ngIf="system === 'single_elim'">
+      Beim K.O.-System scheidet ein Team nach einer Niederlage aus.
+    </p>
+    <p *ngIf="system === 'double_elim'">
+      Beim Double K.O. scheidet ein Team erst nach zwei Niederlagen aus.
+    </p>
+    <p *ngIf="system === 'group_ko'">
+      Teams spielen zunächst in Gruppen und die Besten treten im K.O.-System an.
+    </p>
+    <p>{{ getBeerInfo() }}</p>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button mat-button mat-dialog-close>OK</button>
+  </mat-dialog-actions>
+</ng-template>

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.scss
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.scss
@@ -1,3 +1,29 @@
 .start-season {
+  max-width: 800px;
+  margin: auto;
   padding: 1rem;
+
+  .team-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  .players-select {
+    min-width: 200px;
+  }
+
+  .beer-info {
+    margin: 0.5rem 0;
+    font-style: italic;
+  }
+
+  button {
+    margin-top: 0.5rem;
+  }
 }

--- a/spielolympiade-frontend/src/app/pages/start-season/start-season.component.ts
+++ b/spielolympiade-frontend/src/app/pages/start-season/start-season.component.ts
@@ -1,6 +1,14 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, TemplateRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { MatCheckboxModule, MatCheckboxChange } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatListModule } from '@angular/material/list';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
@@ -10,17 +18,33 @@ const API_URL = environment.apiUrl;
 @Component({
   selector: 'app-start-season',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatListModule,
+    MatIconModule,
+    MatDialogModule,
+  ],
   templateUrl: './start-season.component.html',
   styleUrls: ['./start-season.component.scss']
 })
 export class StartSeasonComponent {
   http = inject(HttpClient);
   router = inject(Router);
+  dialog = inject(MatDialog);
+
+  @ViewChild('systemInfo') systemInfo!: TemplateRef<unknown>;
 
   step = 1;
   year = new Date().getFullYear() + 1;
   name = 'Spielolympiade ' + this.year;
+
+  seasons: any[] = [];
 
   players: any[] = [];
   selectedPlayers: any[] = [];
@@ -36,27 +60,33 @@ export class StartSeasonComponent {
 
   ngOnInit(): void {
     this.http.get<any[]>(`${API_URL}/users`).subscribe((u) => (this.players = u));
-    this.http
-      .get<any>(`${API_URL}/seasons/public/dashboard-data`)
-      .subscribe((d) => (this.games = d.games));
+    this.http.get<any[]>(`${API_URL}/games`).subscribe((g) => (this.games = g));
+    this.http.get<any[]>(`${API_URL}/seasons`).subscribe((s) => {
+      this.seasons = s;
+      const maxYear = this.seasons.reduce(
+        (max, cur) => (cur.year > max ? cur.year : max),
+        new Date().getFullYear()
+      );
+      this.year = maxYear + 1;
+      this.name = 'Spielolympiade ' + this.year;
+    });
   }
 
-  togglePlayer(p: any, event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
-    if (checked) this.selectedPlayers.push(p);
-    else this.selectedPlayers = this.selectedPlayers.filter((x) => x.id !== p.id);
-  }
 
   getPlayerName(id: string): string {
     return this.players.find((p) => p.id === id)?.name ?? id;
   }
 
-  getGameName(id: string): string {
-    return this.games.find((g) => g.id === id)?.name ?? id;
+  formatPlayers(ids: string[]): string {
+    return ids.map((id) => this.getPlayerName(id)).join(', ');
   }
 
-  toggleGame(id: string, event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
+  getGameName = (id: string): string => {
+    return this.games.find((g) => g.id === id)?.name ?? id;
+  };
+
+  toggleGame(id: string, event: MatCheckboxChange): void {
+    const checked = event.checked;
     if (checked) this.selectedGameIds.push(id);
     else this.selectedGameIds = this.selectedGameIds.filter((g) => g !== id);
   }
@@ -66,6 +96,15 @@ export class StartSeasonComponent {
     this.teams.push({ name: this.newTeamName, playerIds: [...this.newTeamPlayers] });
     this.newTeamName = '';
     this.newTeamPlayers = [];
+  }
+
+  removeTeam(index: number): void {
+    this.teams.splice(index, 1);
+  }
+
+  availablePlayers(): any[] {
+    const used = this.teams.flatMap((t) => t.playerIds);
+    return this.selectedPlayers.filter((p) => !used.includes(p.id));
   }
 
   generateTeams(): void {
@@ -93,6 +132,48 @@ export class StartSeasonComponent {
 
   prev(): void {
     if (this.step > 1) this.step--;
+  }
+
+  openInfo(): void {
+    this.dialog.open(this.systemInfo);
+  }
+
+  getBeerInfo(): string {
+    const teams = this.teams.length;
+    const games = this.selectedGameIds.length || 1;
+
+    if (teams <= 1) {
+      return '0 Bier';
+    }
+
+    switch (this.system) {
+      case 'round_robin': {
+        const beers = (teams - 1) * games;
+        return `${beers} Bier pro Person`;
+      }
+      case 'single_elim': {
+        const rounds = Math.ceil(Math.log2(teams));
+        const beers = rounds * games;
+        return `${beers} Bier pro Person`;
+      }
+      case 'double_elim': {
+        const rounds = Math.ceil(Math.log2(teams)) * 2;
+        const beers = rounds * games;
+        return `${beers} Bier pro Person`;
+      }
+      case 'group_ko': {
+        const groupA = Math.ceil(teams / 2);
+        const groupB = Math.floor(teams / 2);
+        const minGroup = Math.min(groupA, groupB) - 1;
+        const maxGroup = Math.max(groupA, groupB) - 1;
+        const groupOnly = `${minGroup * games}-${maxGroup * games}`;
+        const semi = `${(minGroup + 1) * games}-${(maxGroup + 1) * games}`;
+        const finale = `${(minGroup + 2) * games}-${(maxGroup + 2) * games}`;
+        return `Nur Gruppenphase: ${groupOnly}, Halbfinale: ${semi}, Finale/Platz 3: ${finale}`;
+      }
+      default:
+        return '0 Bier';
+    }
   }
 
   start(): void {


### PR DESCRIPTION
## Summary
- use new `/games` route in start-season form
- hide already-picked players when creating teams
- show beer count per game and add group KO system option
- support new `group_ko` tournament mode in backend
- add `/tournaments/:id/start-ko-phase` route to create KO matches
- randomize groups per game for group/KO setup and show detailed beer info
- compute next season year from existing seasons
- allow deleting seasons and view group standings

## Testing
- `npx ng build --configuration development --no-progress` *(fails: could not determine executable to run)*
- `npm test --silent -- --no-watch --browsers=ChromeHeadless` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68710c237918832c82fcfc66e11c08a4