### PR TITLE
Improve history filtering

### DIFF
--- a/spielolympiade-frontend/src/app/pages/history/history.component.html
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.html
@@ -20,7 +20,7 @@
     <div class="filters">
       <label>
         Spiel:
-        <select [(ngModel)]="gameFilter">
+        <select [(ngModel)]="gameFilter" (ngModelChange)="onGameFilterChange()">
           <option value="all">Alle</option>
           <option *ngFor="let g of gameOptions" [value]="g.id">{{ g.name }}</option>
         </select>
@@ -33,6 +33,27 @@
         </select>
       </label>
     </div>
+    <h4>Tabelle</h4>
+    <table class="score-table">
+      <thead>
+        <tr>
+          <th>Team</th>
+          <th>Spiele</th>
+          <th>Siege</th>
+          <th>Niederl.</th>
+          <th>Punkte</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let t of tableData">
+          <td>{{ t.name }}</td>
+          <td>{{ t.spiele }}</td>
+          <td>{{ t.siege }}</td>
+          <td>{{ t.niederlagen }}</td>
+          <td>{{ t.points }}</td>
+        </tr>
+      </tbody>
+    </table>
     <table class="result-table">
       <thead>
         <tr>

--- a/spielolympiade-frontend/src/app/pages/history/history.component.scss
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.scss
@@ -29,3 +29,17 @@ ul {
     text-align: left;
   }
 }
+
+.score-table {
+  margin-top: 1rem;
+  width: 100%;
+  border-collapse: collapse;
+  th,
+  td {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid #ccc;
+  }
+  th {
+    text-align: left;
+  }
+}

--- a/spielolympiade-frontend/src/app/pages/history/history.component.ts
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.ts
@@ -22,6 +22,7 @@ export class HistoryComponent {
   teamFilter = 'all';
   gameOptions: any[] = [];
   teamOptions: any[] = [];
+  tableData: any[] = [];
 
   ngOnInit(): void {
     this.loadSeasons();
@@ -45,6 +46,7 @@ export class HistoryComponent {
         this.teamOptions = this.selected.teams;
         this.gameFilter = 'all';
         this.teamFilter = 'all';
+        this.updateTable();
       });
   }
 
@@ -64,5 +66,37 @@ export class HistoryComponent {
       );
     }
     return matches;
+  }
+
+  onGameFilterChange(): void {
+    this.updateTable();
+  }
+
+  updateTable(): void {
+    if (!this.selected) {
+      this.tableData = [];
+      return;
+    }
+    let matches = this.selected.tournaments[0]?.matches.filter((m: any) => m.winnerId) || [];
+    if (this.gameFilter !== 'all') {
+      matches = matches.filter((m: any) => m.game.id === this.gameFilter);
+    }
+    const teams = this.selected.teams;
+    const table = teams.map((t: any) => {
+      const teamMatches = matches.filter((m: any) => m.team1Id === t.id || m.team2Id === t.id);
+      const wins = teamMatches.filter((m: any) => m.winnerId === t.id).length;
+      const games = teamMatches.length;
+      const losses = games - wins;
+      return {
+        id: t.id,
+        name: t.name,
+        spiele: games,
+        siege: wins,
+        niederlagen: losses,
+        points: wins,
+      };
+    });
+    table.sort((a: any, b: any) => b.points - a.points);
+    this.tableData = table;
   }
 }


### PR DESCRIPTION
## Summary
- show ranking table on the history page
- compute table data for selected season
- allow filtering by game with table update

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871270d4230832c966ee310026670a4