### PR TITLE
Add Angular Material dark mode toggle

### DIFF
--- a/spielolympiade-frontend/angular.json
+++ b/spielolympiade-frontend/angular.json
@@ -24,10 +24,9 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": [
-              "node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.scss"
-            ],
+              "styles": [
+                "src/styles.scss"
+              ],
             "scripts": []
           },
           "configurations": {
@@ -86,10 +85,9 @@
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": [
-              "node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.scss"
-            ],
+              "styles": [
+                "src/styles.scss"
+              ],
             "scripts": []
           }
         }

--- a/spielolympiade-frontend/src/app/app.component.html
+++ b/spielolympiade-frontend/src/app/app.component.html
@@ -1,6 +1,9 @@
 <mat-toolbar color="primary" *ngIf="auth.isLoggedIn()" class="main-nav">
   <a routerLink="/dashboard" class="title">Willkommen zur Spielolympiade</a>
   <span class="spacer"></span>
+  <mat-slide-toggle (change)="toggleDarkMode($event.checked)" [checked]="darkMode">
+    Dark Mode
+  </mat-slide-toggle>
   <button mat-icon-button [matMenuTriggerFor]="menu">
     <mat-icon>more_vert</mat-icon>
   </button>

--- a/spielolympiade-frontend/src/app/app.component.scss
+++ b/spielolympiade-frontend/src/app/app.component.scss
@@ -12,6 +12,10 @@ mat-toolbar.main-nav {
     font-size: 1.25rem;
     font-weight: 500;
   }
+
+  mat-slide-toggle {
+    margin-right: 0.5rem;
+  }
 }
 
 .spacer {

--- a/spielolympiade-frontend/src/app/app.component.ts
+++ b/spielolympiade-frontend/src/app/app.component.ts
@@ -4,8 +4,10 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AuthService } from './core/auth.service';
 import { NgIf } from '@angular/common';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'app-root',
@@ -17,15 +19,30 @@ import { NgIf } from '@angular/common';
     MatButtonModule,
     MatIconModule,
     MatMenuModule,
+    MatSlideToggleModule,
     NgIf,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
 export class AppComponent {
-  constructor(public auth: AuthService) {}
+  darkMode = false;
+
+  constructor(public auth: AuthService, private overlayContainer: OverlayContainer) {}
 
   logout(): void {
     this.auth.logout();
+  }
+
+  toggleDarkMode(isDark: boolean): void {
+    this.darkMode = isDark;
+    const classList = this.overlayContainer.getContainerElement().classList;
+    if (isDark) {
+      document.body.classList.add('dark-theme');
+      classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
+      classList.remove('dark-theme');
+    }
   }
 }

--- a/spielolympiade-frontend/src/styles.scss
+++ b/spielolympiade-frontend/src/styles.scss
@@ -14,4 +14,19 @@ $my-theme: mat.define-light-theme((
   )
 ));
 
+$dark-primary: mat.define-palette(mat.$blue-grey-palette);
+$dark-accent: mat.define-palette(mat.$deep-orange-palette);
+
+$dark-theme: mat.define-dark-theme((
+  color: (
+    primary: $dark-primary,
+    accent: $dark-accent,
+    warn: $my-warn,
+  )
+));
+
 @include mat.all-component-themes($my-theme);
+
+.dark-theme {
+  @include mat.all-component-colors($dark-theme);
+}


### PR DESCRIPTION
## Summary
- add Angular Material slide toggle for dark mode
- implement dark and light themes in SCSS
- update component styles
- remove prebuilt theme from angular.json

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687182b83578832c842508b68741fcc2