### PR TITLE
Improve admin security and dashboard result entry

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -108,6 +108,7 @@
 
   <section *ngIf="activeGameDay">
     <h2>Spiele</h2>
+    <h3>Aktuelle Begegnungen</h3>
     <div class="filters">
       <button mat-raised-button (click)="setFilter('all')">Alle Begegnungen</button>
       <button mat-raised-button (click)="setFilter('open')">Offen</button>
@@ -118,15 +119,45 @@
       <li *ngFor="let r of filteredGames">
         {{ getGameName(r.gameId) }} |
         {{ getTeamName(r.team1Id) }}
-        <input *ngIf="auth.getUser()?.role === 'admin'" type="number" [(ngModel)]="r.team1Score" style="width:40px" />
-        <span *ngIf="auth.getUser()?.role !== 'admin'">({{ r.team1Score ?? '-' }})</span>
+        <ng-container *ngIf="auth.getUser()?.role === 'admin'; else view1">
+          <select [(ngModel)]="r.team1Score" (ngModelChange)="setWinner(r, $event == null ? 'none' : ($event == 1 ? 'team1' : 'team2'))">
+            <option [ngValue]="null">offen</option>
+            <option [ngValue]="1">gewonnen</option>
+            <option [ngValue]="0">verloren</option>
+          </select>
+        </ng-container>
+        <ng-template #view1>({{ r.team1Score ?? '-' }})</ng-template>
         –
         {{ getTeamName(r.team2Id) }}
-        <input *ngIf="auth.getUser()?.role === 'admin'" type="number" [(ngModel)]="r.team2Score" style="width:40px" />
-        <span *ngIf="auth.getUser()?.role !== 'admin'">({{ r.team2Score ?? '-' }})</span>
-        <button *ngIf="auth.getUser()?.role === 'admin'" mat-button color="accent" (click)="saveResultFor(r)">Speichern</button>
+        <ng-container *ngIf="auth.getUser()?.role === 'admin'; else view2">
+          <select [(ngModel)]="r.team2Score" (ngModelChange)="setWinner(r, $event == null ? 'none' : ($event == 1 ? 'team2' : 'team1'))">
+            <option [ngValue]="null">offen</option>
+            <option [ngValue]="1">gewonnen</option>
+            <option [ngValue]="0">verloren</option>
+          </select>
+        </ng-container>
+        <ng-template #view2>({{ r.team2Score ?? '-' }})</ng-template>
+        <button *ngIf="auth.getUser()?.role === 'admin'" mat-icon-button color="accent" (click)="toggleSave(r)">
+          <mat-icon>{{ r.saved ? 'edit' : 'save' }}</mat-icon>
+        </button>
       </li>
     </ul>
+    <div *ngIf="auth.getUser()?.role === 'admin'" class="new-match">
+      <h4>Neues Spiel</h4>
+      <select [(ngModel)]="newMatch.team1Id">
+        <option value="" disabled selected>Team 1</option>
+        <option *ngFor="let t of allTeams" [value]="t.id">{{ t.name }}</option>
+      </select>
+      <select [(ngModel)]="newMatch.team2Id">
+        <option value="" disabled selected>Team 2</option>
+        <option *ngFor="let t of allTeams" [value]="t.id">{{ t.name }}</option>
+      </select>
+      <select [(ngModel)]="newMatch.gameId">
+        <option value="" disabled selected>Spiel</option>
+        <option *ngFor="let g of allGames" [value]="g.id">{{ g.name }}</option>
+      </select>
+      <button mat-raised-button color="primary" (click)="createMatch()">Anlegen</button>
+    </div>
   </section>
 
 

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
 import { HttpClient } from '@angular/common/http';
 import { AuthService } from '../../core/auth.service';
 import { environment } from '../../../environments/environment';
@@ -30,6 +31,7 @@ const API_URL = environment.apiUrl;
     MatCardModule,
     MatCheckboxModule,
     MatSelectModule,
+    MatIconModule,
     FormsModule,
   ],
   templateUrl: './dashboard.component.html',
@@ -42,6 +44,7 @@ export class DashboardComponent {
   allTeams: any[] = [];
   allGames: any[] = [];
   allMatches: any[] = [];
+  newMatch: any = { team1Id: '', team2Id: '', gameId: '' };
   todayResults: any[] = [];
   upcomingGames: any[] = [];
   tableData: any[] = [];
@@ -112,6 +115,7 @@ export class DashboardComponent {
             ...m,
             team1Score: m.results.find((r: any) => r.teamId === m.team1Id)?.score ?? null,
             team2Score: m.results.find((r: any) => r.teamId === m.team2Id)?.score ?? null,
+            saved: true,
           })
         );
         this.tournamentSystem = data.tournament?.system || 'round_robin';
@@ -173,9 +177,28 @@ export class DashboardComponent {
         team2Score: m.team2Score,
       })
       .subscribe(() => {
+        m.saved = true;
         this.loadData();
         this.loadTable();
       });
+  }
+
+  toggleSave(m: any): void {
+    if (m.saved) {
+      const password = prompt('Passwort zum Bearbeiten eingeben:');
+      if (!password) return;
+      const username = this.auth.getUser()?.username;
+      this.http
+        .post(`${API_URL}/auth/login`, { username, password })
+        .subscribe({
+          next: () => {
+            m.saved = false;
+          },
+          error: () => alert('Passwort falsch'),
+        });
+    } else {
+      this.saveResultFor(m);
+    }
   }
 
   groupStandings(gameId: string): Record<string, { teamId: string; points: number }[]> {
@@ -210,11 +233,47 @@ export class DashboardComponent {
     );
   }
 
+  createMatch(): void {
+    if (!this.newMatch.team1Id || !this.newMatch.team2Id || !this.newMatch.gameId) return;
+    const tournamentId = this.allMatches[0]?.tournamentId;
+    this.http
+      .post(`${API_URL}/matches`, {
+        tournamentId,
+        gameId: this.newMatch.gameId,
+        team1Id: this.newMatch.team1Id,
+        team2Id: this.newMatch.team2Id,
+      })
+      .subscribe(() => {
+        this.newMatch = { team1Id: '', team2Id: '', gameId: '' };
+        this.loadData();
+      });
+  }
+
+  setWinner(m: any, winner: 'team1' | 'team2' | 'none'): void {
+    if (winner === 'team1') {
+      m.team1Score = 1;
+      m.team2Score = 0;
+    } else if (winner === 'team2') {
+      m.team1Score = 0;
+      m.team2Score = 1;
+    } else {
+      m.team1Score = null;
+      m.team2Score = null;
+    }
+    m.saved = false;
+  }
+
   deleteSeason(): void {
     if (!this.team?.seasonId) return;
-    this.http.delete(`${API_URL}/seasons/${this.team.seasonId}`).subscribe(() => {
-      this.seasonActive = false;
-      this.loadData();
-    });
+    const password = prompt('Bitte Passwort zum Löschen eingeben:');
+    if (!password) return;
+    this.http
+      .request('delete', `${API_URL}/seasons/${this.team.seasonId}`, {
+        body: { password },
+      })
+      .subscribe(() => {
+        this.seasonActive = false;
+        this.loadData();
+      });
   }
 }

--- a/spielolympiade-frontend/src/app/pages/history/history.component.ts
+++ b/spielolympiade-frontend/src/app/pages/history/history.component.ts
@@ -82,9 +82,13 @@ export class HistoryComponent {
   }
 
   deleteSeason(id: string): void {
-    this.http.delete(`${API_URL}/seasons/${id}`).subscribe(() => {
-      this.selected = null;
-      this.loadSeasons();
-    });
+    const password = prompt('Bitte Passwort zum Löschen eingeben:');
+    if (!password) return;
+    this.http
+      .request('delete', `${API_URL}/seasons/${id}`, { body: { password } })
+      .subscribe(() => {
+        this.selected = null;
+        this.loadSeasons();
+      });
   }
 }


### PR DESCRIPTION
## Summary
- require password when deleting a season
- update admin pages to prompt for a password on deletion
- add dropdown based result entry with save/edit toggle
- allow creating a new match from the dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `spielolympiade-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687182512db0832cb15eeed95683a907