### PR TITLE
Add dashboard link in menu

### DIFF
--- a/spielolympiade-frontend/src/app/app.component.html
+++ b/spielolympiade-frontend/src/app/app.component.html
@@ -11,6 +11,7 @@
 
 <mat-menu #menu="matMenu">
   <button mat-menu-item routerLink="/history">Historie</button>
+  <button mat-menu-item routerLink="/dashboard">Dashboard</button>
   <button mat-menu-item routerLink="/admin" *ngIf="auth.getUser()?.role === 'admin'">Userverwaltung</button>
   <button mat-menu-item (click)="logout()">Logout</button>
 </mat-menu>


### PR DESCRIPTION
## Summary
- link the dashboard from the three-dot menu

## Testing
- `npm test` (root)
- `npm test` in `spielolympiade-backend`
- `npm test` in `spielolympiade-frontend` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687188a23ffc832c913496a9745ecdab