### PR TITLE
Fix dark mode toggling

### DIFF
--- a/spielolympiade-frontend/src/app/app.component.ts
+++ b/spielolympiade-frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterOutlet, RouterLink } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
@@ -25,10 +25,17 @@ import { OverlayContainer } from '@angular/cdk/overlay';
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   darkMode = false;
 
   constructor(public auth: AuthService, private overlayContainer: OverlayContainer) {}
+
+  ngOnInit(): void {
+    const saved = localStorage.getItem('darkMode');
+    if (saved === 'true') {
+      this.toggleDarkMode(true);
+    }
+  }
 
   logout(): void {
     this.auth.logout();
@@ -36,6 +43,7 @@ export class AppComponent {
 
   toggleDarkMode(isDark: boolean): void {
     this.darkMode = isDark;
+    localStorage.setItem('darkMode', `${isDark}`);
     const classList = this.overlayContainer.getContainerElement().classList;
     if (isDark) {
       document.body.classList.add('dark-theme');


### PR DESCRIPTION
## Summary
- remember dark mode setting in localStorage
- restore dark mode on startup

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687187bb3f04832ca49130b399eb7596