### PR TITLE
Fix README password example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ ng serve
 ### backend/.env
 
 ```
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/spielolympiade
+DATABASE_URL=postgresql://postgres:<dein_passwort>@localhost:5432/spielolympiade
 PORT=3000
 JWT_SECRET=dein_geheimer_jwt_schluessel
 ```


### PR DESCRIPTION
## Summary
- hide password in README example `.env`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871877e0dac832cabc237ebf7d45421