### PR TITLE
Implement game scheduling algorithm

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -108,6 +108,18 @@
 
   <section *ngIf="activeGameDay">
     <h2>Spiele</h2>
+    <div *ngIf="recommendations.length" class="recommendations">
+      <h3>Empfohlene nächste Spiele</h3>
+      <ul>
+        <li *ngFor="let g of recommendations | slice:0:5">
+          {{ getGameName(g.gameId) }}: {{ getTeamName(g.team1Id) }} vs
+          {{ getTeamName(g.team2Id) }}
+          <button mat-button color="primary" (click)="startMatch(g.id)">
+            Jetzt spielen
+          </button>
+        </li>
+      </ul>
+    </div>
     <div class="filters">
       <button mat-raised-button (click)="setFilter('all')">Alle Begegnungen</button>
       <button mat-raised-button (click)="setFilter('open')">Offen</button>

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -60,10 +60,12 @@ export class DashboardComponent {
   filterMode: 'all' | 'open' | 'played' = 'open';
   onlyMine = false;
   filteredGames: any[] = [];
+  recommendations: any[] = [];
 
   ngOnInit(): void {
     this.loadMyTeam();
     this.loadData();
+    this.loadRecommendations();
   }
 
   loadMyTeam(): void {
@@ -175,6 +177,7 @@ export class DashboardComponent {
       .subscribe(() => {
         this.loadData();
         this.loadTable();
+        this.loadRecommendations();
       });
   }
 
@@ -208,6 +211,23 @@ export class DashboardComponent {
     return this.allMatches.filter(
       (m) => m.gameId === gameId && m.stage !== 'group'
     );
+  }
+
+  loadRecommendations(): void {
+    this.http
+      .get<any[]>(`${API_URL}/matches/recommendations`)
+      .subscribe({
+        next: (data) => (this.recommendations = data),
+        error: (err) =>
+          console.error('Fehler beim Laden der Empfehlungen', err),
+      });
+  }
+
+  startMatch(id: string): void {
+    this.http.post(`${API_URL}/matches/${id}/start`, {}).subscribe(() => {
+      this.loadData();
+      this.loadRecommendations();
+    });
   }
 
   deleteSeason(): void {


### PR DESCRIPTION
## Summary
- add API to recommend upcoming matches based on team wait time and current games in progress
- allow all users to start a match via `/matches/:id/start`
- show recommendations on dashboard with start buttons

## Testing
- `npm test --silent` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871841f0828832cbdf8cbe064986965