### PR TITLE
Fix team name display

### DIFF
--- a/src/app/history/history.component.html
+++ b/src/app/history/history.component.html
@@ -17,10 +17,12 @@
   </div>
 
   <ul class="list-group">
-    <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let result of filteredResults">
-      <span>{{ getGameName(result.gameId) }}</span>
-      <span class="fw-bold">{{ formatResult(result) }}</span>
-      <button class="btn btn-danger btn-sm" (click)="deleteResult(result.id)">Löschen</button>
-    </li>
+      <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let result of filteredResults">
+        <span>{{ getGameName(result.gameId) }}</span>
+        <span class="fw-bold">
+          {{ result.team1Id | teamName }} {{ result.team1Score }}:{{ result.team2Score }} {{ result.team2Id | teamName }}
+        </span>
+        <button class="btn btn-danger btn-sm" (click)="deleteResult(result.id)">Löschen</button>
+      </li>
   </ul>
 </div>

--- a/src/app/history/history.component.ts
+++ b/src/app/history/history.component.ts
@@ -4,6 +4,7 @@ import { Game } from '../models/game.model';
 import { Result } from '../models/result.model';
 import {Team} from '../models/team.model'
 import { NgFor } from '@angular/common';
+import { TeamNamePipe } from '../team-name.pipe';
 import { FormsModule } from '@angular/forms';
 
 @Component({
@@ -11,7 +12,7 @@ import { FormsModule } from '@angular/forms';
   templateUrl: './history.component.html',
   styleUrls: ['./history.component.css'],
   standalone: true,
-  imports: [NgFor, FormsModule],
+  imports: [NgFor, FormsModule, TeamNamePipe],
 })
 export class HistoryComponent implements OnInit {
   results: Result[] = [];

--- a/src/app/team-name.pipe.ts
+++ b/src/app/team-name.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TournamentService } from './tournament.service';
+import { Team } from './models/team.model';
+
+@Pipe({
+  name: 'teamName',
+  standalone: true
+})
+export class TeamNamePipe implements PipeTransform {
+  private teams: Team[] = [];
+
+  constructor(private tournamentService: TournamentService) {
+    this.tournamentService.getTeams().subscribe(t => this.teams = t);
+  }
+
+  transform(teamId: string): string {
+    const team = this.teams.find(t => t.id === teamId);
+    return team ? team.name : teamId;
+  }
+}


### PR DESCRIPTION
## Summary
- create `TeamNamePipe` to map team id to team name
- use the new pipe in the history list

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718df8a0a0832cae01e891ad9a0484