### PR TITLE
Fix recommended matches team name issue

### DIFF
--- a/spielolympiade-backend/src/routes/matches.ts
+++ b/spielolympiade-backend/src/routes/matches.ts
@@ -24,7 +24,15 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
 router.get(
   "/recommendations",
   async (_req: Request, res: Response): Promise<void> => {
-    const all = await prisma.match.findMany();
+    const season = await prisma.season.findFirst({ where: { isActive: true } });
+    if (!season) {
+      res.json([]);
+      return;
+    }
+
+    const all = await prisma.match.findMany({
+      where: { tournament: { seasonId: season.id } },
+    });
 
     const lastPlayed: Record<string, Date> = {};
     const inProgress: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- ensure `/matches/recommendations` only returns matches from the active season

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run build` in backend *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6871907cc068832c872b326494339e97