### PR TITLE
Move delete season button

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -15,12 +15,6 @@
   </div>
 
   <ng-container *ngIf="seasonActive">
-    <button
-      mat-raised-button
-      color="warn"
-      *ngIf="auth.getUser()?.role === 'admin'"
-      (click)="deleteSeason()"
-    >Saison löschen</button>
 
     <div class="view-switch" *ngIf="tournamentSystem === 'group_ko'">
       <mat-form-field appearance="fill">
@@ -150,5 +144,11 @@
       </li>
     </ul>
   </section>
+  <button
+    mat-raised-button
+    color="warn"
+    *ngIf="auth.getUser()?.role === 'admin'"
+    (click)="deleteSeason()"
+  >Löschen</button>
   </ng-container>
 </div>


### PR DESCRIPTION
## Summary
- move the dashboard delete season button to the bottom and rename it to `Löschen`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871908c8c18832c89e4b2db53120a51