### PR TITLE
Improve team display

### DIFF
--- a/spielolympiade-frontend/src/app/pages/teams/teams.component.html
+++ b/spielolympiade-frontend/src/app/pages/teams/teams.component.html
@@ -1,1 +1,12 @@
-<p>teams works!</p>
+<div class="team-list">
+  <mat-card class="team-card" *ngFor="let t of teams">
+    <mat-card-title>{{ t.name }}</mat-card-title>
+    <mat-card-content>
+      <mat-list>
+        <mat-list-item *ngFor="let m of t.members">
+          {{ m.user.name }}
+        </mat-list-item>
+      </mat-list>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/spielolympiade-frontend/src/app/pages/teams/teams.component.scss
+++ b/spielolympiade-frontend/src/app/pages/teams/teams.component.scss
@@ -1,0 +1,12 @@
+
+.team-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.team-card {
+  width: 200px;
+}
+

--- a/spielolympiade-frontend/src/app/pages/teams/teams.component.ts
+++ b/spielolympiade-frontend/src/app/pages/teams/teams.component.ts
@@ -1,12 +1,31 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
+import { environment } from '../../../environments/environment';
+
+const API_URL = environment.apiUrl;
 
 @Component({
   selector: 'app-teams',
   standalone: true,
-  imports: [],
+  imports: [CommonModule, MatCardModule, MatListModule],
   templateUrl: './teams.component.html',
-  styleUrl: './teams.component.scss'
+  styleUrls: ['./teams.component.scss'],
 })
 export class TeamsComponent {
+  http = inject(HttpClient);
 
+  teams: any[] = [];
+
+  ngOnInit(): void {
+    this.http.get<any[]>(`${API_URL}/teams`).subscribe((data) => {
+      this.teams = data;
+    });
+  }
+
+  getMemberNames(team: any): string {
+    return team.members.map((m: any) => m.user.name).join(', ');
+  }
 }


### PR DESCRIPTION
## Summary
- implement team overview page
- fetch teams from API and list members
- add styling for team cards

## Testing
- `npm install` *(fails: some packages missing?)*
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687190b34f14832c8e78bb85082bf2e6