### PR TITLE
Add dropdown result editing

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -136,19 +136,52 @@
       <button mat-raised-button (click)="setFilter('played')">Gespielt</button>
       <mat-checkbox [(ngModel)]="onlyMine" (change)="applyFilters()">Nur meine Spiele</mat-checkbox>
     </div>
-    <ul>
-      <li *ngFor="let r of filteredGames">
-        {{ getGameName(r.gameId) }} |
-        {{ getTeamName(r.team1Id) }}
-        <input *ngIf="auth.getUser()?.role === 'admin'" type="number" [(ngModel)]="r.team1Score" style="width:40px" />
-        <span *ngIf="auth.getUser()?.role !== 'admin'">({{ r.team1Score ?? '-' }})</span>
-        –
-        {{ getTeamName(r.team2Id) }}
-        <input *ngIf="auth.getUser()?.role === 'admin'" type="number" [(ngModel)]="r.team2Score" style="width:40px" />
-        <span *ngIf="auth.getUser()?.role !== 'admin'">({{ r.team2Score ?? '-' }})</span>
-        <button *ngIf="auth.getUser()?.role === 'admin'" mat-button color="accent" (click)="saveResultFor(r)">Speichern</button>
-      </li>
-    </ul>
-  </section>
+    <table class="result-table">
+      <thead>
+        <tr>
+          <th>Spiel</th>
+          <th>Team 1</th>
+          <th>Ergebnis</th>
+          <th>Team 2</th>
+          <th>Ergebnis</th>
+          <th *ngIf="auth.getUser()?.role === 'admin'"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let r of filteredGames">
+          <td>{{ getGameName(r.gameId) }}</td>
+          <td>{{ getTeamName(r.team1Id) }}</td>
+          <td>
+            <ng-container *ngIf="auth.getUser()?.role === 'admin'; else t1score">
+              <mat-form-field appearance="fill" class="score-select">
+                <mat-select [ngModel]="r.team1Score" (ngModelChange)="updateResult(r, 'team1', $event)">
+                  <mat-option [value]="1">gewonnen</mat-option>
+                  <mat-option [value]="0">verloren</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </ng-container>
+            <ng-template #t1score>{{ r.team1Score ?? '-' }}</ng-template>
+          </td>
+          <td>{{ getTeamName(r.team2Id) }}</td>
+          <td>
+            <ng-container *ngIf="auth.getUser()?.role === 'admin'; else t2score">
+              <mat-form-field appearance="fill" class="score-select">
+                <mat-select [ngModel]="r.team2Score" (ngModelChange)="updateResult(r, 'team2', $event)">
+                  <mat-option [value]="1">gewonnen</mat-option>
+                  <mat-option [value]="0">verloren</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </ng-container>
+            <ng-template #t2score>{{ r.team2Score ?? '-' }}</ng-template>
+          </td>
+          <td class="action-cell" *ngIf="auth.getUser()?.role === 'admin'">
+            <button mat-icon-button color="accent" (click)="toggleSave(r)">
+              <mat-icon>{{ r.saved ? 'edit' : 'save' }}</mat-icon>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    </section>
   </ng-container>
 </div>

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.scss
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.scss
@@ -82,3 +82,23 @@
   width: 100px;
   margin: 0 0.5rem;
 }
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid #ccc;
+  }
+
+  th {
+    text-align: left;
+  }
+}
+
+.action-cell {
+  width: 40px;
+  text-align: center;
+}

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -176,6 +176,17 @@ export class DashboardComponent {
     return this.allGames.find((g) => g.id === id)?.name ?? id;
   }
 
+  updateResult(m: any, team: 'team1' | 'team2', value: number): void {
+    if (team === 'team1') {
+      m.team1Score = value;
+      m.team2Score = value === 1 ? 0 : 1;
+    } else {
+      m.team2Score = value;
+      m.team1Score = value === 1 ? 0 : 1;
+    }
+    m.saved = false;
+  }
+
   saveResultFor(m: any): void {
     this.http
       .put(`${API_URL}/matches/${m.id}/result`, {


### PR DESCRIPTION
## Summary
- switch results list to table layout
- allow admins to set win/loss via dropdown
- auto-fill opposite team when selecting result
- show save/edit icons

## Testing
- `npx ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_687190faaea4832cb061f216a38d30a6