### PR TITLE
Automate KO rounds

### DIFF
--- a/spielolympiade-backend/src/routes/tournaments.ts
+++ b/spielolympiade-backend/src/routes/tournaments.ts
@@ -1,109 +1,15 @@
 import express, { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
 import { authorizeRole } from "../middleware/auth";
+import { progressTournament } from "../utils/tournament";
 
 const router = express.Router();
-const prisma = new PrismaClient();
 
-// POST /tournaments/:id/start-ko-phase - generate KO matches after group stage
+// Manuell KO-Phase oder Finale starten
 router.post(
-  "/:id/start-ko-phase",
+  "/:id/progress",
   authorizeRole("admin"),
   async (req: Request, res: Response): Promise<void> => {
-    const { id } = req.params;
-    const tournament = await prisma.tournament.findUnique({
-      where: { id },
-      include: { matches: { include: { results: true } } },
-    });
-    if (!tournament) {
-      res.status(404).json({ error: "Turnier nicht gefunden" });
-      return;
-    }
-
-    if (tournament.system !== "group_ko") {
-      res.status(400).json({ error: "Nur für Gruppen-KO Turniere" });
-      return;
-    }
-
-    const games = [
-      ...new Set(tournament.matches.map((m: any) => m.gameId)),
-    ] as string[];
-
-    for (const gameId of games) {
-      const groupMatches = tournament.matches.filter(
-        (m: any) => m.gameId === gameId && m.stage === "group"
-      );
-      const groups: Record<string, any[]> = {};
-      for (const m of groupMatches) {
-        if (!m.groupName) continue;
-        groups[m.groupName] = groups[m.groupName] || [];
-        if (!groups[m.groupName].includes(m.team1Id))
-          groups[m.groupName].push(m.team1Id);
-        if (!groups[m.groupName].includes(m.team2Id))
-          groups[m.groupName].push(m.team2Id);
-      }
-
-      const standings: Record<string, { teamId: string; points: number }[]> = {};
-      for (const m of groupMatches) {
-        if (!m.winnerId) {
-          res.status(400).json({ error: "Gruppenspiele noch nicht abgeschlossen" });
-          return;
-        }
-        const group = m.groupName as string;
-        standings[group] = standings[group] || groups[group].map((t) => ({ teamId: t, points: 0 }));
-        const entry = standings[group].find((s) => s.teamId === m.winnerId);
-        if (entry) entry.points += 1;
-      }
-
-      for (const group of Object.keys(standings)) {
-        standings[group].sort((a, b) => b.points - a.points);
-      }
-
-      const semi1Team1 = standings["A"][0].teamId;
-      const semi1Team2 = standings["B"][1].teamId;
-      const semi2Team1 = standings["B"][0].teamId;
-      const semi2Team2 = standings["A"][1].teamId;
-
-      const semi1 = await prisma.match.create({
-        data: {
-          tournamentId: tournament.id,
-          gameId,
-          team1Id: semi1Team1,
-          team2Id: semi1Team2,
-          stage: "semi_final",
-        },
-      });
-      const semi2 = await prisma.match.create({
-        data: {
-          tournamentId: tournament.id,
-          gameId,
-          team1Id: semi2Team1,
-          team2Id: semi2Team2,
-          stage: "semi_final",
-        },
-      });
-
-      await prisma.match.create({
-        data: {
-          tournamentId: tournament.id,
-          gameId,
-          team1Id: semi1.winnerId || semi1Team1,
-          team2Id: semi2.winnerId || semi2Team1,
-          stage: "final",
-        },
-      });
-
-      await prisma.match.create({
-        data: {
-          tournamentId: tournament.id,
-          gameId,
-          team1Id: semi1.winnerId ? semi2Team2 : semi1Team1,
-          team2Id: semi2.winnerId ? semi1Team2 : semi2Team1,
-          stage: "third_place",
-        },
-      });
-    }
-
+    await progressTournament(req.params.id);
     res.json({ success: true });
   }
 );

--- a/spielolympiade-backend/src/utils/tournament.ts
+++ b/spielolympiade-backend/src/utils/tournament.ts
@@ -1,0 +1,96 @@
+import { PrismaClient, Match } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function progressTournament(tournamentId: string): Promise<void> {
+  const tournament = await prisma.tournament.findUnique({
+    where: { id: tournamentId },
+    include: { matches: true },
+  });
+  if (!tournament || tournament.system !== "group_ko") return;
+
+  const games = Array.from(
+    new Set(tournament.matches.map((m) => m.gameId))
+  ) as string[];
+
+  for (const gameId of games) {
+    const byStage = (stage: string) =>
+      tournament.matches.filter(
+        (m) => m.gameId === gameId && m.stage === stage
+      );
+
+    const groupMatches = byStage("group");
+    if (
+      groupMatches.length > 0 &&
+      groupMatches.every((m) => m.winnerId)
+    ) {
+      const semiExists = byStage("semi_final").length > 0;
+      if (!semiExists) {
+        const groups: Record<string, string[]> = {};
+        for (const m of groupMatches) {
+          if (!m.groupName) continue;
+          groups[m.groupName] = groups[m.groupName] || [];
+          if (!groups[m.groupName].includes(m.team1Id))
+            groups[m.groupName].push(m.team1Id);
+          if (!groups[m.groupName].includes(m.team2Id))
+            groups[m.groupName].push(m.team2Id);
+        }
+        const standings: Record<string, { teamId: string; points: number }[]> = {};
+        for (const m of groupMatches) {
+          const g = m.groupName as string;
+          standings[g] =
+            standings[g] || groups[g].map((t) => ({ teamId: t, points: 0 }));
+          const entry = standings[g].find((s) => s.teamId === m.winnerId);
+          if (entry) entry.points += 1;
+        }
+        for (const g of Object.keys(standings)) {
+          standings[g].sort((a, b) => b.points - a.points);
+        }
+        await prisma.match.create({
+          data: {
+            tournamentId,
+            gameId,
+            team1Id: standings["A"][0].teamId,
+            team2Id: standings["B"][1].teamId,
+            stage: "semi_final",
+          },
+        });
+        await prisma.match.create({
+          data: {
+            tournamentId,
+            gameId,
+            team1Id: standings["B"][0].teamId,
+            team2Id: standings["A"][1].teamId,
+            stage: "semi_final",
+          },
+        });
+      }
+    }
+
+    const semis = byStage("semi_final");
+    if (semis.length === 2 && semis.every((m) => m.winnerId)) {
+      const finals = byStage("final");
+      if (finals.length === 0) {
+        const [s1, s2] = semis;
+        await prisma.match.create({
+          data: {
+            tournamentId,
+            gameId,
+            team1Id: s1.winnerId as string,
+            team2Id: s2.winnerId as string,
+            stage: "final",
+          },
+        });
+        await prisma.match.create({
+          data: {
+            tournamentId,
+            gameId,
+            team1Id: s1.team1Id === s1.winnerId ? s1.team2Id : s1.team1Id,
+            team2Id: s2.team1Id === s2.winnerId ? s2.team2Id : s2.team1Id,
+            stage: "third_place",
+          },
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add tournament progress helper to generate KO matches
- simplify tournament routes to single `/progress` endpoint
- update match result routes to trigger tournament progression
- allow deleting matches with password validation

## Testing
- `npm run build` *(fails: Cannot find module '@prisma/client')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68719335abe4832c9ede536704351cd3