### PR TITLE
Add admin delete button on dashboard

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -177,5 +177,10 @@
       </tbody>
     </table>
     </section>
+    <div class="delete-wrapper" *ngIf="auth.getUser()?.role === 'admin'">
+      <button mat-raised-button color="warn" (click)="deleteSeason()">
+        Saison löschen
+      </button>
+    </div>
   </ng-container>
 </div>

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.scss
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.scss
@@ -102,3 +102,8 @@
   width: 40px;
   text-align: center;
 }
+
+.delete-wrapper {
+  margin-top: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- allow admin to delete season from dashboard
- center delete button and add spacing

## Testing
- `npm run build`
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6871998e9540832c82d21af81299f4f6