### PR TITLE
Implement season finish button

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="dashboard">
   <div class="info" *ngIf="!seasonActive">
     <p>
-      Die Spielolympiade beginnt bald!
+      Die Spielolympiade beginnt bald! Die nächste Spielolympiade ist dieses Jahr 2025.
       <a routerLink="/history">Werfe doch ein Blick in die Historie!</a>
     </p>
     <button
@@ -174,8 +174,16 @@
             </button>
           </td>
         </tr>
-      </tbody>
-    </table>
+    </tbody>
+  </table>
     </section>
+    <button
+      mat-raised-button
+      color="primary"
+      *ngIf="auth.getUser()?.role === 'admin'"
+      (click)="finishSeason()"
+    >
+      Saison speichern
+    </button>
   </ng-container>
 </div>

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -281,4 +281,16 @@ export class DashboardComponent {
         this.loadData();
       });
   }
+
+  finishSeason(): void {
+    if (!this.team?.seasonId) return;
+    const password = prompt('Bitte Passwort zum Speichern eingeben:');
+    if (!password) return;
+    this.http
+      .post(`${API_URL}/seasons/${this.team.seasonId}/finish`, { password })
+      .subscribe(() => {
+        this.seasonActive = false;
+        this.loadData();
+      });
+  }
 }


### PR DESCRIPTION
## Summary
- show that the next Spielolympiade is in 2025
- allow admins to finish a season from the dashboard with a password prompt

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687199dca7c8832ca8d02c73b628587c