### PR TITLE
Fix tournament dashboard logic

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -117,20 +117,43 @@
                   {{ getTeamName(row.teamId) }}
                 </td>
               </ng-container>
-              <ng-container matColumnDef="points">
+              <ng-container *ngIf="groupPhaseComplete(viewMode)" matColumnDef="points">
                 <th mat-header-cell *matHeaderCellDef>Punkte</th>
                 <td mat-cell *matCellDef="let row">{{ row.points }}</td>
               </ng-container>
-              <tr mat-header-row *matHeaderRowDef="['team', 'points']"></tr>
+              <tr
+                mat-header-row
+                *matHeaderRowDef="groupPhaseComplete(viewMode) ? ['team', 'points'] : ['team']"
+              ></tr>
               <tr
                 mat-row
-                *matRowDef="let row; columns: ['team', 'points']"
+                *matRowDef="let row; columns: groupPhaseComplete(viewMode) ? ['team', 'points'] : ['team']"
               ></tr>
+            </table>
+          </div>
+          <div *ngIf="overallStandings(viewMode).length" class="overall-table">
+            <h4>Gesamtwertung</h4>
+            <table mat-table [dataSource]="overallStandings(viewMode)" class="result-table">
+              <ng-container matColumnDef="rank">
+                <th mat-header-cell *matHeaderCellDef>Platz</th>
+                <td mat-cell *matCellDef="let row">{{ row.rank }}</td>
+              </ng-container>
+              <ng-container matColumnDef="team">
+                <th mat-header-cell *matHeaderCellDef>Team</th>
+                <td mat-cell *matCellDef="let row">{{ getTeamName(row.teamId) }}</td>
+              </ng-container>
+              <ng-container matColumnDef="ratio">
+                <th mat-header-cell *matHeaderCellDef>Quote</th>
+                <td mat-cell *matCellDef="let row">{{ row.ratio | number:'1.2-2' }}</td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="['rank','team','ratio']"></tr>
+              <tr mat-row *matRowDef="let row; columns: ['rank','team','ratio']"></tr>
             </table>
           </div>
           <h4>K.O.-Phase</h4>
           <mat-list>
             <mat-list-item *ngFor="let m of koMatchesFor(viewMode)">
+              <strong>{{ stageLabel(m.stage) }}:</strong>
               {{ getTeamName(m.team1Id) }} vs {{ getTeamName(m.team2Id) }} -
               <ng-container
                 *ngIf="m.team1Score != null && m.team2Score != null; else open"
@@ -166,6 +189,33 @@
             </button>
           </li>
         </ul>
+      </div>
+      <div class="new-match" *ngIf="auth.getUser()?.role === 'admin'">
+        <h3>Spiel hinzufügen</h3>
+        <mat-form-field appearance="fill">
+          <mat-select [(ngModel)]="newMatch.gameId" placeholder="Spiel">
+            <mat-option *ngFor="let g of allGames" [value]="g.id">
+              {{ g.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-select [(ngModel)]="newMatch.team1Id" placeholder="Team 1">
+            <mat-option *ngFor="let t of allTeams" [value]="t.id">
+              {{ t.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-select [(ngModel)]="newMatch.team2Id" placeholder="Team 2">
+            <mat-option *ngFor="let t of allTeams" [value]="t.id">
+              {{ t.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button mat-raised-button color="primary" (click)="createMatch()">
+          Anlegen
+        </button>
       </div>
       <div class="filters">
         <button mat-raised-button (click)="setFilter('all')">

--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -48,6 +48,7 @@ export class DashboardComponent {
   allTeams: any[] = [];
   allGames: any[] = [];
   allMatches: any[] = [];
+  tournament: any = null;
   newMatch: any = { team1Id: '', team2Id: '', gameId: '' };
   todayResults: any[] = [];
   upcomingGames: any[] = [];
@@ -116,6 +117,7 @@ export class DashboardComponent {
       next: (data) => {
         this.allTeams = data.teams;
         this.allGames = data.games;
+        this.tournament = data.tournament;
         this.allMatches = (data.tournament ? data.tournament.matches : []).map(
           (m: any) => ({
             ...m,
@@ -249,6 +251,93 @@ export class DashboardComponent {
     return this.allMatches.filter(
       (m) => m.gameId === gameId && m.stage !== 'group'
     );
+  }
+
+  groupPhaseComplete(gameId: string): boolean {
+    const matches = this.allMatches.filter(
+      (m) => m.gameId === gameId && m.stage === 'group'
+    );
+    return matches.length > 0 && matches.every((m) => m.winnerId);
+  }
+
+  stageLabel(stage: string): string {
+    switch (stage) {
+      case 'semi_final':
+        return 'Halbfinale';
+      case 'final':
+        return 'Finale';
+      case 'third_place':
+        return 'Spiel um Platz 3';
+      default:
+        return stage;
+    }
+  }
+
+  overallStandings(gameId: string): { teamId: string; wins: number; losses: number; ratio: number }[] {
+    if (!this.groupPhaseComplete(gameId)) return [];
+    const stats: Record<string, { wins: number; losses: number }> = {};
+    const matches = this.allMatches.filter(
+      (m) => m.gameId === gameId && m.stage === 'group'
+    );
+    for (const m of matches) {
+      stats[m.team1Id] = stats[m.team1Id] || { wins: 0, losses: 0 };
+      stats[m.team2Id] = stats[m.team2Id] || { wins: 0, losses: 0 };
+      if (m.winnerId) {
+        const loser = m.team1Id === m.winnerId ? m.team2Id : m.team1Id;
+        stats[m.winnerId].wins += 1;
+        stats[loser].losses += 1;
+      }
+    }
+
+    let table = Object.entries(stats).map(([teamId, s]) => ({
+      teamId,
+      wins: s.wins,
+      losses: s.losses,
+      ratio: s.wins + s.losses > 0 ? s.wins / (s.wins + s.losses) : 0,
+    }));
+
+    const final = this.allMatches.find(
+      (m) => m.gameId === gameId && m.stage === 'final' && m.winnerId
+    );
+    const third = this.allMatches.find(
+      (m) => m.gameId === gameId && m.stage === 'third_place' && m.winnerId
+    );
+
+    if (final && third) {
+      const finalLoser = final.team1Id === final.winnerId ? final.team2Id : final.team1Id;
+      const thirdLoser = third.team1Id === third.winnerId ? third.team2Id : third.team1Id;
+      const ranking = [
+        final.winnerId,
+        finalLoser,
+        third.winnerId,
+        thirdLoser,
+      ];
+      table = ranking
+        .map((t) => table.find((e) => e.teamId === t)!)
+        .filter(Boolean)
+        .concat(table.filter((e) => !ranking.includes(e.teamId)))
+        .map((e, idx) => ({ ...e, rank: idx + 1 }));
+    } else {
+      table.sort((a, b) => b.ratio - a.ratio);
+      table = table.map((e, idx) => ({ ...e, rank: idx + 1 }));
+    }
+
+    return table;
+  }
+
+  createMatch(): void {
+    if (!this.newMatch.team1Id || !this.newMatch.team2Id || !this.newMatch.gameId)
+      return;
+    const payload = {
+      tournamentId: this.tournament?.id,
+      gameId: this.newMatch.gameId,
+      team1Id: this.newMatch.team1Id,
+      team2Id: this.newMatch.team2Id,
+    };
+    this.http.post(`${API_URL}/matches`, payload).subscribe(() => {
+      this.newMatch = { team1Id: '', team2Id: '', gameId: '' };
+      this.loadData();
+    });
   }
 
   loadRecommendations(): void {


### PR DESCRIPTION
## Summary
- show KO stage labels and game standings across groups
- support manual tiebreak matches

## Testing
- `npm test` (fails: ng not found)
- `npm run build` in backend (fails: missing packages)


------
https://chatgpt.com/codex/tasks/task_e_6871a99a60b4832c82b98053b849d30b