### PR TITLE
Auto refresh frontend data

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewChild } from '@angular/core';
+import { Component, inject, ViewChild, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -41,7 +41,7 @@ const API_URL = environment.apiUrl;
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
 })
-export class DashboardComponent {
+export class DashboardComponent implements OnInit, OnDestroy {
   auth = inject(AuthService);
   http = inject(HttpClient);
   team: any;
@@ -69,10 +69,22 @@ export class DashboardComponent {
   filteredGames: any[] = [];
   recommendations: any[] = [];
 
+  private refreshInterval: any;
+
   ngOnInit(): void {
     this.loadMyTeam();
     this.loadData();
     this.loadRecommendations();
+
+    this.refreshInterval = setInterval(() => {
+      this.loadMyTeam();
+      this.loadData();
+      this.loadRecommendations();
+    }, 10000);
+  }
+
+  ngOnDestroy(): void {
+    clearInterval(this.refreshInterval);
   }
 
   loadMyTeam(): void {

--- a/spielolympiade-frontend/src/app/pages/teams/teams.component.ts
+++ b/spielolympiade-frontend/src/app/pages/teams/teams.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { MatCardModule } from '@angular/material/card';
@@ -14,12 +14,23 @@ const API_URL = environment.apiUrl;
   templateUrl: './teams.component.html',
   styleUrls: ['./teams.component.scss'],
 })
-export class TeamsComponent {
+export class TeamsComponent implements OnInit, OnDestroy {
   http = inject(HttpClient);
 
   teams: any[] = [];
 
+  private refreshInterval: any;
+
   ngOnInit(): void {
+    this.loadTeams();
+    this.refreshInterval = setInterval(() => this.loadTeams(), 10000);
+  }
+
+  ngOnDestroy(): void {
+    clearInterval(this.refreshInterval);
+  }
+
+  loadTeams(): void {
     this.http.get<any[]>(`${API_URL}/teams`).subscribe((data) => {
       this.teams = data;
     });


### PR DESCRIPTION
## Summary
- add `OnInit`/`OnDestroy` with refresh timer in dashboard
- periodically reload team list in teams page

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871aa06d7e0832c8381bc5b8d1afc52