### PR TITLE
Implement group KO scoring improvements

### DIFF
--- a/spielolympiade-backend/src/routes/seasons.ts
+++ b/spielolympiade-backend/src/routes/seasons.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { calculateGroupKoStandings } from "../utils/tournament";
 import { createHash } from "crypto";
 import { authorizeRole } from "../middleware/auth";
 
@@ -115,7 +116,7 @@ router.get("/:id/table", async (req: Request, res: Response): Promise<void> => {
 
   const season = await prisma.season.findUnique({
     where: { id },
-    include: { teams: true },
+    include: { teams: true, tournaments: { include: { matches: true } } },
   });
 
   if (!season) {
@@ -123,30 +124,51 @@ router.get("/:id/table", async (req: Request, res: Response): Promise<void> => {
     return;
   }
 
-  const matches = await prisma.match.findMany({
-    where: { tournament: { seasonId: id }, winnerId: { not: null } },
-    select: { id: true, team1Id: true, team2Id: true, winnerId: true },
-  });
+  const stats = season.teams.map((t: any) => ({
+    id: t.id,
+    name: t.name,
+    spiele: 0,
+    siege: 0,
+    niederlagen: 0,
+    points: 0,
+  }));
+  const map: Record<string, any> = {};
+  for (const s of stats) map[s.id] = s;
 
-  const table = season.teams.map((team: any) => {
-    const teamMatches = matches.filter(
-      (m: any) => m.team1Id === team.id || m.team2Id === team.id
-    );
-    const wins = teamMatches.filter((m: any) => m.winnerId === team.id).length;
-    const games = teamMatches.length;
-    const losses = games - wins;
-    const points = wins; // 1 Punkt pro Sieg
-    return {
-      id: team.id,
-      name: team.name,
-      spiele: games,
-      siege: wins,
-      niederlagen: losses,
-      points,
-    };
-  });
+  for (const t of season.tournaments) {
+    for (const m of t.matches) {
+      if (!m.team1Id || !m.team2Id) continue;
+      if (m.winnerId) {
+        map[m.team1Id].spiele += 1;
+        map[m.team2Id].spiele += 1;
+        if (m.winnerId === m.team1Id) {
+          map[m.team1Id].siege += 1;
+          map[m.team2Id].niederlagen += 1;
+        } else {
+          map[m.team2Id].siege += 1;
+          map[m.team1Id].niederlagen += 1;
+        }
+      }
+    }
 
-  table.sort((a: any, b: any) => b.points - a.points);
+    if (t.system === "round_robin") {
+      for (const m of t.matches) {
+        if (m.winnerId) map[m.winnerId].points += 1;
+      }
+    } else if (t.system === "group_ko") {
+      const gameIds = Array.from(new Set(t.matches.map((m) => m.gameId))) as string[];
+      for (const gameId of gameIds) {
+        const standings = calculateGroupKoStandings(
+          t.matches.filter((m) => m.gameId === gameId)
+        );
+        for (const s of standings) {
+          map[s.teamId].points += s.points;
+        }
+      }
+    }
+  }
+
+  const table = Object.values(map).sort((a: any, b: any) => b.points - a.points);
 
   res.json(table);
 });

--- a/spielolympiade-backend/src/routes/tournaments.ts
+++ b/spielolympiade-backend/src/routes/tournaments.ts
@@ -1,8 +1,10 @@
 import express, { Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
 import { authorizeRole } from "../middleware/auth";
-import { progressTournament } from "../utils/tournament";
+import { progressTournament, calculateGroupKoStandings } from "../utils/tournament";
 
 const router = express.Router();
+const prisma = new PrismaClient();
 
 // Manuell KO-Phase oder Finale starten
 router.post(
@@ -11,6 +13,38 @@ router.post(
   async (req: Request, res: Response): Promise<void> => {
     await progressTournament(req.params.id);
     res.json({ success: true });
+  }
+);
+
+// Aktuelle Platzierungen eines group_ko Turniers
+router.get(
+  "/:id/standings",
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const tournament = await prisma.tournament.findUnique({
+      where: { id },
+      include: { matches: true },
+    });
+
+    if (!tournament) {
+      res.status(404).json({ error: "Turnier nicht gefunden" });
+      return;
+    }
+
+    if (tournament.system !== "group_ko") {
+      res.status(400).json({ error: "Nur f\u00fcr group_ko verf\u00fcgbar" });
+      return;
+    }
+
+    const games = Array.from(new Set(tournament.matches.map((m) => m.gameId))) as string[];
+    const result = games.map((gameId) => ({
+      gameId,
+      standings: calculateGroupKoStandings(
+        tournament.matches.filter((m) => m.gameId === gameId)
+      ),
+    }));
+
+    res.json(result);
   }
 );
 

--- a/spielolympiade-backend/src/utils/tournament.ts
+++ b/spielolympiade-backend/src/utils/tournament.ts
@@ -94,3 +94,70 @@ export async function progressTournament(tournamentId: string): Promise<void> {
     }
   }
 }
+
+export function calculateGroupKoStandings(matches: Match[]): {
+  teamId: string;
+  wins: number;
+  losses: number;
+  ratio: number;
+  rank: number;
+  points: number;
+}[] {
+  const stats: Record<string, { wins: number; losses: number }> = {};
+
+  // zunächst Siege/Niederlagen der Gruppenphase erfassen
+  for (const m of matches.filter((x) => x.stage === "group")) {
+    stats[m.team1Id] = stats[m.team1Id] || { wins: 0, losses: 0 };
+    stats[m.team2Id] = stats[m.team2Id] || { wins: 0, losses: 0 };
+    if (m.winnerId) {
+      const loser = m.team1Id === m.winnerId ? m.team2Id : m.team1Id;
+      stats[m.winnerId].wins += 1;
+      stats[loser].losses += 1;
+    }
+  }
+
+  // sicherstellen, dass Teams ohne Gruppensieg auch im Stats-Objekt sind
+  for (const m of matches) {
+    stats[m.team1Id] = stats[m.team1Id] || { wins: 0, losses: 0 };
+    stats[m.team2Id] = stats[m.team2Id] || { wins: 0, losses: 0 };
+  }
+
+  const table = Object.entries(stats).map(([teamId, s]) => ({
+    teamId,
+    wins: s.wins,
+    losses: s.losses,
+    ratio: s.wins + s.losses > 0 ? s.wins / (s.wins + s.losses) : 0,
+  }));
+
+  // Platz 1-4 werden über die KO-Phase bestimmt
+  const final = matches.find((m) => m.stage === "final" && m.winnerId);
+  const third = matches.find((m) => m.stage === "third_place" && m.winnerId);
+
+  let ranking: string[] = [];
+  if (final && third) {
+    const finalLoser = final.team1Id === final.winnerId ? final.team2Id : final.team1Id;
+    const thirdLoser = third.team1Id === third.winnerId ? third.team2Id : third.team1Id;
+    ranking = [final.winnerId, finalLoser, third.winnerId, thirdLoser];
+  }
+
+  const ordered = ranking
+    .map((id) => table.find((t) => t.teamId === id)!)
+    .filter(Boolean)
+    .concat(
+      table
+        .filter((t) => !ranking.includes(t.teamId))
+        .sort((a, b) => {
+          if (b.ratio !== a.ratio) return b.ratio - a.ratio;
+          return Math.random() - 0.5; // Zufall bei Gleichstand
+        })
+    );
+
+  const totalTeams = ordered.length;
+
+  return ordered.map((e, idx) => ({
+    ...e,
+    rank: idx + 1,
+    points: totalTeams - (idx + 1),
+  }));
+}
+

--- a/spielolympiade-backend/src/utils/tournament.ts
+++ b/spielolympiade-backend/src/utils/tournament.ts
@@ -152,12 +152,11 @@ export function calculateGroupKoStandings(matches: Match[]): {
         })
     );
 
-  const totalTeams = ordered.length;
-
+  const pointsTable = [8, 6, 4, 3, 2, 1];
   return ordered.map((e, idx) => ({
     ...e,
     rank: idx + 1,
-    points: totalTeams - (idx + 1),
+    points: pointsTable[idx] ?? 0,
   }));
 }
 


### PR DESCRIPTION
## Summary
- refine `calculateGroupKoStandings` to use group records and dynamic points
- ensure teams with identical records are shuffled

## Testing
- `npm run build` *(fails: cannot find @prisma/client types and implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871bdb48a24832c97d368f47f30d3a0