### PR TITLE
Implement match recommendations

### DIFF
--- a/src/app/history/history.component.html
+++ b/src/app/history/history.component.html
@@ -16,6 +16,16 @@
     </div>
   </div>
 
+  <div class="mb-4">
+    <h3>Empfohlene Spiele</h3>
+    <ul class="list-group">
+      <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let match of recommendedMatches" [ngClass]="{'bg-primary text-white': match.playing}">
+        <span>{{ match.game.name }}: {{ match.team1.name }} vs. {{ match.team2.name }}</span>
+        <button class="btn btn-success btn-sm" (click)="startMatch(match)">Jetzt spielen</button>
+      </li>
+    </ul>
+  </div>
+
   <ul class="list-group">
       <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let result of filteredResults">
         <span>{{ getGameName(result.gameId) }}</span>


### PR DESCRIPTION
## Summary
- broadcast updates when results change
- compute suggested matchups to fill all stations
- list recommended matches on the history page with a **Jetzt spielen** button

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_687241486e30832c9e9afeb91a38d055