### PR TITLE
Adjust game tables

### DIFF
--- a/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/spielolympiade-frontend/src/app/pages/dashboard/dashboard.component.html
@@ -117,18 +117,12 @@
                   {{ getTeamName(row.teamId) }}
                 </td>
               </ng-container>
-              <ng-container *ngIf="groupPhaseComplete(viewMode)" matColumnDef="points">
+              <ng-container matColumnDef="points">
                 <th mat-header-cell *matHeaderCellDef>Punkte</th>
                 <td mat-cell *matCellDef="let row">{{ row.points }}</td>
               </ng-container>
-              <tr
-                mat-header-row
-                *matHeaderRowDef="groupPhaseComplete(viewMode) ? ['team', 'points'] : ['team']"
-              ></tr>
-              <tr
-                mat-row
-                *matRowDef="let row; columns: groupPhaseComplete(viewMode) ? ['team', 'points'] : ['team']"
-              ></tr>
+              <tr mat-header-row *matHeaderRowDef="['team', 'points']"></tr>
+              <tr mat-row *matRowDef="let row; columns: ['team', 'points']"></tr>
             </table>
           </div>
           <div *ngIf="overallStandings(viewMode).length" class="overall-table">


### PR DESCRIPTION
## Summary
- always show points in the group tables
- compute standings even if the group phase isn’t finished

## Testing
- `npm test` *(fails: Missing script)*
- `npx ng build` *(fails: could not determine executable)*
- `npx tsc -p spielolympiade-frontend/tsconfig.json` *(fails: missing Angular dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872385eb1e0832c84d60f8f2bbed19a